### PR TITLE
Fix ridge regression example: change x0 to init in solve_cg

### DIFF
--- a/examples/ridge_reg_implicit_diff.py
+++ b/examples/ridge_reg_implicit_diff.py
@@ -47,7 +47,7 @@ def ridge_solver(init_params, l2reg, data):
   return linear_solve.solve_cg(matvec=matvec,
                                b=jnp.dot(X_tr.T, y_tr),
                                ridge=len(y_tr) * l2reg,
-                               x0=init_params,
+                               init=init_params,
                                maxiter=20)
 
 


### PR DESCRIPTION
The current ridge regression example is broken with the following error:

```
TypeError: jax._src.scipy.sparse.linalg.cg() got multiple values for keyword argument 'x0'
```

I believe this stems from the fact that `linear_solve.solve_cg` takes `init` as opposed to `x0` as a named parameter

https://github.com/google/jaxopt/blob/e42a1ff6f80ca2a3dae5fa60c2a7fedad91d527c/jaxopt/_src/linear_solve.py#L109