### PR TITLE
Add implicit_diff_solve, jit, unroll options and reorganize base classes

### DIFF
--- a/jaxopt/_src/gradient_descent.py
+++ b/jaxopt/_src/gradient_descent.py
@@ -39,10 +39,9 @@ class GradientDescent(ProximalGradient):
     acceleration: whether to use acceleration (also known as FISTA) or not.
     verbose: whether to print error on every iteration or not.
       Warning: verbose=True will automatically disable jit.
-    implicit_diff: if True, enable implicit differentiation using cg,
-      if Callable, do implicit differentiation using callable as linear solver,
-      if False, use autodiff through the solver implementation (note:
-        this will unroll syntactic loops).
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled
+      iterations.
+    implicit_diff_solve: the linear system solver to use.
     has_aux: whether function fun outputs one (False) or more values (True).
       When True it will be assumed by default that fun(...)[0] is the objective.
   """

--- a/jaxopt/_src/polyak_sgd.py
+++ b/jaxopt/_src/polyak_sgd.py
@@ -18,14 +18,14 @@ from typing import Any
 from typing import Callable
 from typing import NamedTuple
 from typing import Optional
-from typing import Union
 
 import dataclasses
 
 import jax
 import jax.numpy as jnp
 
-from jaxopt import base
+from jaxopt._src import base
+from jaxopt._src import linear_solve
 from jaxopt.tree_util import tree_add
 from jaxopt.tree_util import tree_add_scalar_mul
 from jaxopt.tree_util import tree_l2_norm
@@ -44,7 +44,7 @@ class PolyakSGDState(NamedTuple):
 
 
 @dataclasses.dataclass
-class PolyakSGD(base.IterativeSolverMixin, base.StochasticSolverMixin):
+class PolyakSGD(base.StochasticSolver):
   """SGD with Polyak step size.
 
   This solver computes step sizes in an adaptive manner. If the computed step
@@ -69,14 +69,15 @@ class PolyakSGD(base.IterativeSolverMixin, base.StochasticSolverMixin):
     tol: tolerance to use.
     verbose: whether to print error on every iteration or not. verbose=True will
       automatically disable jit.
-    implicit_diff: if True, enable implicit differentiation using cg,
-      if Callable, do implicit differentiation using callable as linear solver,
-      if False, use autodiff through the solver implementation (note:
-        this will unroll syntactic loops).
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled
+      iterations.
+    implicit_diff_solve: the linear system solver to use.
     has_aux: whether ``fun`` outputs one (False) or more values (True).
       When True it will be assumed by default that ``fun(...)[0]``
       is the objective value. The auxiliary outputs are stored in
       ``state.aux``.
+    jit: whether to JIT-compile the optimization loop (default: "auto").
+    unroll: whether to unroll the optimization loop (default: "auto").
 
   References:
     Berrada, Leonard and Zisserman, Andrew and Kumar, M Pawan.
@@ -99,8 +100,11 @@ class PolyakSGD(base.IterativeSolverMixin, base.StochasticSolverMixin):
   maxiter: int = 500
   tol: float = 1e-3
   verbose: int = 0
-  implicit_diff: Union[bool, Callable] = False
+  implicit_diff: bool = False
+  implicit_diff_solve: Callable = linear_solve.solve_normal_cg
   has_aux: bool = False
+  jit: base.AutoOrBoolean = "auto"
+  unroll: base.AutoOrBoolean = "auto"
 
   def init(self,
            init_params: Any,
@@ -145,6 +149,9 @@ class PolyakSGD(base.IterativeSolverMixin, base.StochasticSolverMixin):
     Returns:
       (params, state)
     """
+    if self.pre_update:
+      params, state = self.pre_update(params, state, *args, **kwargs)
+
     (value, aux), grad = self._value_and_grad_fun(params, *args, **kwargs)
 
     grad_sqnorm = tree_l2_norm(grad, squared=True)
@@ -182,6 +189,3 @@ class PolyakSGD(base.IterativeSolverMixin, base.StochasticSolverMixin):
     # Pre-compile useful functions.
     self._value_and_grad_fun = jax.value_and_grad(fun_with_aux, has_aux=True)
     self._grad_fun = jax.grad(fun_with_aux, has_aux=True)
-
-    # TODO(mblondel): run_iterator needs to be decorated as well.
-    self._set_implicit_diff_run()

--- a/jaxopt/_src/quadratic_prog.py
+++ b/jaxopt/_src/quadratic_prog.py
@@ -151,7 +151,7 @@ def _make_quadratic_prog_optimality_fun(matvec_Q, matvec_A):
 
 
 @dataclass
-class QuadraticProgramming:
+class QuadraticProgramming(base.Solver):
   """Quadratic programming solver.
 
   The objective function is::
@@ -164,12 +164,14 @@ class QuadraticProgramming:
     matvec_A: a Callable matvec_A(params_A, u).
       By default, matvec_A(A, u) = dot(A, u), where A = params_A.
     maxiter: maximum number of iterations.
+    implicit_diff_solve: the linear system solver to use.
   """
 
   # TODO(mblondel): add matvec_G when we implement our own QP solvers.
   matvec_Q: Optional[Callable] = None
   matvec_A: Optional[Callable] = None
   maxiter: int = 1000
+  implicit_diff_solve: Callable = linear_solve.solve_normal_cg
 
   def run(self,
           init_params: Optional[Tuple] = None,
@@ -227,6 +229,7 @@ class QuadraticProgramming:
                                                               self.matvec_A)
 
     # Set up implicit diff.
-    decorator = idf.custom_root(self.optimality_fun, has_aux=True)
+    decorator = idf.custom_root(self.optimality_fun, has_aux=True,
+                                solve=self.implicit_diff_solve)
     # pylint: disable=g-missing-from-attributes
     self.run = decorator(self.run)

--- a/jaxopt/base.py
+++ b/jaxopt/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jaxopt._src.base import IterativeSolverMixin
+from jaxopt._src.base import IterativeSolver
 from jaxopt._src.base import LinearOperator
 from jaxopt._src.base import OptStep
-from jaxopt._src.base import StochasticSolverMixin
+from jaxopt._src.base import StochasticSolver


### PR DESCRIPTION
This PR implements several core changes.

1) Add an `implicit_diff_solve` option for specifying the linear solver to use for doing implicit diff (previously the `implicit_diff` served *both* the purpose of enabling/disabling implicit diff and of specifying the solver)

2) Add `jit` and `unroll` option to all solvers for finer-grained control on how the optimization loop is performed

3) Move `pre_update` to within `update` in `OptaxSolver` and `PolyakSGD` (fixes #27)

4) Reorganize and rename classes. Since Python is increasingly used as a typed language, it will be useful if we can create functions that accept a solver as argument
```
def some_func(solver: jaxopt.base.IterativeSolver):
```