### PR TITLE
Quad solver fix

### DIFF
--- a/jaxopt/_src/linear_solve.py
+++ b/jaxopt/_src/linear_solve.py
@@ -154,6 +154,7 @@ def solve_normal_cg(matvec: Callable,
 def solve_gmres(matvec: Callable,
                 b: Any,
                 ridge: Optional[float] = None,
+                tol: float = 1e-5,
                 **kwargs) -> Any:
   """Solves ``A x = b`` using gmres.
 
@@ -168,7 +169,7 @@ def solve_gmres(matvec: Callable,
   """
   if ridge is not None:
     matvec = _make_ridge_matvec(matvec, ridge=ridge)
-  return jax.scipy.sparse.linalg.gmres(matvec, b, **kwargs)[0]
+  return jax.scipy.sparse.linalg.gmres(matvec, b, tol=tol, **kwargs)[0]
 
 
 def solve_bicgstab(matvec: Callable,

--- a/jaxopt/_src/quadratic_prog.py
+++ b/jaxopt/_src/quadratic_prog.py
@@ -69,7 +69,9 @@ def _solve_eq_constrained_qp(init_params,
                              c,
                              matvec_A,
                              b,
-                             maxiter):
+                             maxiter,
+                             tol=1e-5,
+                             solve=linear_solve.solve_gmres): 
   """Solves 0.5 * x^T Q x + c^T x subject to Ax = b.
 
   This solver returns both the primal solution (x) and the dual solution.
@@ -85,8 +87,7 @@ def _solve_eq_constrained_qp(init_params,
   # Solves the following linear system:
   # [[Q A^T]  [primal_var = [-c
   #  [A 0  ]]  dual_var  ]    b]
-  return linear_solve.solve_cg(matvec, (minus_c, b), init=init_params,
-                               maxiter=maxiter)
+  return solve(matvec, (minus_c, b), tol=tol, maxiter=maxiter)
 
 
 def _solve_constrained_qp_cvxpy(params_obj, params_eq, params_ineq):
@@ -171,6 +172,7 @@ class QuadraticProgramming(base.Solver):
   matvec_Q: Optional[Callable] = None
   matvec_A: Optional[Callable] = None
   maxiter: int = 1000
+  tol: float = 1e-5
   implicit_diff_solve: Callable = linear_solve.solve_normal_cg
 
   def run(self,
@@ -205,7 +207,7 @@ class QuadraticProgramming(base.Solver):
       sol = base.KKTSolution(*_solve_eq_constrained_qp(init_params,
                                                        matvec_Q, c,
                                                        matvec_A, b,
-                                                       self.maxiter))
+                                                       self.maxiter, tol=self.tol))
     else:
       sol = base.KKTSolution(*_solve_constrained_qp_cvxpy(params_obj,
                                                           params_eq,

--- a/tests/quadratic_prog_test.py
+++ b/tests/quadratic_prog_test.py
@@ -86,7 +86,7 @@ class QuadraticProgTest(jtu.JaxTestCase):
     c = jnp.array([1.0, 1.0])
     A = jnp.array([[1.0, 1.0]])
     b = jnp.array([1.0])
-    qp = QuadraticProgramming()
+    qp = QuadraticProgramming(tol=1e-7)
     hyperparams = dict(params_obj=(Q, c), params_eq=(A, b))
     sol = qp.run(**hyperparams).params
     self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0)


### PR DESCRIPTION
Changed the linear solver used  in _solve_eq_constrained_qp_KKT to gminres since the KKT is symmetric but not necessarily positive definite.  This is the recommend solver for this  type of KKT system in Nocedal & Wright, section 16.3, Numerical Optimization. 

I also tried solve_normal_cg instead, but it's convergence in residual is slow, and consequently fails the units test _check_derivative_A_and_b unless significantly increase tolerance (and number of iterations).