### PR TITLE
Add Anderson doc, Picard ODE example, Anderson GD example.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,6 +62,15 @@ Root finding
     jaxopt.Bisection
     jaxopt.ScipyRootFinding
 
+Fixed Point resolution
+----------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.PicardIteration
+    jaxopt.AndersonAcceleration
+
 Implicit differentiation
 ------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,11 +4,13 @@ Changelog
 Version 0.1 (initial release)
 -----------------------------
 
+- :class:`jaxopt.AndersonAcceleration`
 - :class:`jaxopt.Bisection`
 - :class:`jaxopt.BlockCoordinateDescent`
 - :class:`jaxopt.GradientDescent`
 - :class:`jaxopt.MirrorDescent`
 - :class:`jaxopt.OptaxSolver`
+- :class:`jaxopt.PicardIteration`
 - :class:`jaxopt.PolyakSGD`
 - :class:`jaxopt.ProjectedGradient`
 - :class:`jaxopt.ProximalGradient`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,11 +47,11 @@ release = __version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.napoleon', # napoleon on top of autodoc: https://stackoverflow.com/a/66930447 might correct some warnings
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',

--- a/docs/fixed_point.rst
+++ b/docs/fixed_point.rst
@@ -1,0 +1,112 @@
+Fixed Point resolution
+======================
+
+This section is concerned with fixed-point resolution, that is finding :math:`x` such
+that :math:`T(x, \theta) = x`. 
+
+Picard Iteration
+----------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.PicardIteration
+
+Picard iteration is the simplest algorithms for fixed-point finding. It computes the limit of the sequence :math:`x_{n+1}=T(x_n, \theta)` 
+which is guaranteed to exist if :math:`x\mapsto T(x,\theta)` is a **contractive map**. See `Banach fixed-point theorem <https://en.wikipedia.org/wiki/Banach_fixed-point_theorem>`_
+for more details.
+
+Usage of Picard Iterations::
+
+  from jaxopt import PicardIteration
+
+  def T(x, theta):  # contractive map
+    return 0.5 * x + theta
+
+  picard = PicardIteration(fixed_point_fun=T)
+  x_init = jnp.array(0.)
+  theta = jnp.array(0.5)
+  print(picard.run(x_init, theta).params)
+
+``PicardIteration`` successfully finds the root ``x = 1``.  
+
+Differentiation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fixed point computations are efficiently differentiable::
+
+  from jaxopt import PicardIteration
+
+  def T(x, theta):  # contractive map
+    return 0.5 * x + theta
+
+  picard = PicardIteration(fixed_point_fun=T, implicit_diff=True)
+  x_init = jnp.array(0.)
+  theta = jnp.array(0.5)
+
+  def fixed_point(x, theta):
+    return picard.run(x, theta).params
+
+  print(jax.grad(fixed_point, argnums=1)(x_init, theta))  # only gradient
+  print(jax.value_and_grad(fixed_point, argnums=1)(x_init, theta))  # both value and gradient  
+
+Note that :math:`x(\theta)=2\theta` so :math:`\nabla x(\theta)=2`. 
+
+Under the hood, we use the implicit function theorem in order to differentiate the root.
+See the :ref:`implicit differentiation <implicit_diff>` section for more details.
+
+Anderson Acceleration
+---------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.AndersonAcceleration
+
+Anderson acceleration is an iterative method that aims to compute the next iterate :math:`x_{n}` as
+a linear combination of the :math:`m` last iterates :math:`[x_{n-m},x_{n-m+1},\ldots x_{n-1}]`. The optimal coefficients
+of the linear combination are computed 'on the fly' at each iteration. As a result, not only the convergence is faster
+but the convergence conditions are weakened, allowing to tackle problems PicardIterations could not.
+See `this paper <https://arxiv.org/abs/1909.04638>`_ for more details.
+  
+The size of the history :math:`m` (denoted ``history_size`` below) plays a crucial role in method performance. 
+An higher :math:`m` could speed up the convergence at the cost of higher memory consumption, and more numerical instabilities.
+Those numerical instabilities can be mitigated by increasing the ``ridge`` regularization hyper-parameter.
+
+Anderson's acceleration usage is similar to Picard::
+
+  from jaxopt import AndersonAcceleration
+
+  def T(x, theta):  # contractive map
+    return 0.5 * x + theta
+
+  aa = AndersonAcceleration(fixed_point_fun=T, history_size=5, ridge=1e-6, tol=1e-5)
+  x_init = jnp.array(0.)
+  theta = jnp.array(0.5)
+  print(aa.run(x0, theta).params)
+
+For implicit differentiation::
+
+  from jaxopt import AndersonAcceleration
+
+  def T(x, theta):  # contractive map
+    return 0.5 * x + theta
+
+  aa = AndersonAcceleration(fixed_point_fun=T, history_size=5, ridge=1e-6, tol=1e-5, implicit_diff=True)
+  x_init = jnp.array(0.)
+  theta = jnp.array(0.5)
+
+  def fixed_point(x, theta):
+    return picard.run(x, theta).params
+
+  print(jax.grad(fixed_point, argnums=1)(x_init, theta))  # only gradient
+  print(jax.value_and_grad(fixed_point, argnums=1)(x_init, theta))  # both value and gradient
+
+
+Equivalence with root finding
+-----------------------------
+
+Note that if :math:`x` is a fixed point of :math:`T` then :math:`x` is a root of :math:`F(x, \theta) = T(x, \theta) - x`. 
+Reciproqually, if :math:`x` is the root of some :math:`F(x, \theta)` then it is also the fixed point of :math:`T(x, \theta) = F(x, \theta) + x`.
+Hence, root finding and fixed-point resolutions are two different views of the same problem, leading to different approaches.  
+We encourage the reader to take a look at :ref:`root finding <root_finding>` section and chose the most appropriate tool for the use-case.  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ You may install JAXopt from GitHub with::
    stochastic
    objective_and_loss
    root_finding
+   fixed_point
    implicit_diff
 
 .. toctree::

--- a/docs/objective_and_loss.rst
+++ b/docs/objective_and_loss.rst
@@ -70,6 +70,7 @@ Other functions
 .. autosummary::
   :toctree: _autosummary
 
+    jaxopt.objective.ridge_regression
     jaxopt.objective.multiclass_logreg_with_intercept
     jaxopt.objective.l2_multiclass_logreg
     jaxopt.objective.l2_multiclass_logreg_with_intercept

--- a/examples/plot_anderson_accelerate_gd.py
+++ b/examples/plot_anderson_accelerate_gd.py
@@ -1,0 +1,109 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Anderson acceleration of gradient descent.
+==========================================
+
+For a strictly convex function f, :math:`\nabla f(x)=0` implies that :math:`x` is the global optimum :math:`f`.
+
+Consequently the fixed point of :math:`T(x)=x-\eta\nabla f(x)` is the optimum of :math:`f`.
+
+Note that repeated application of the operator :math:`T` coincides exactlty with gradient descent with constant step size :math:`\eta`.
+
+Hence, as any other fixed point iteration, gradient descent can benefit from Anderson acceleration.
+Here, we chose chose :math:`f` as the objective function of ridge regression on some dummy dataset.
+Anderson acceleration reaches the optimal parameters within few iterations, whereas Gradient Descent is slower.
+"""
+
+
+import jax
+import jax.numpy as jnp
+
+from jaxopt import AndersonAcceleration
+from jaxopt import PicardIteration
+
+from jaxopt import objective
+from jaxopt.tree_util import tree_scalar_mul, tree_sub
+
+import matplotlib.pyplot as plt
+from sklearn import datasets
+
+jax.config.update("jax_platform_name", "cpu")
+
+
+# retrieve intermediate iterates.
+def run_all(solver, w_init, *args, **kwargs):
+  sol, state = solver.init(w_init, *args, **kwargs)
+  sols, errors = [sol], [state.error]
+  for _ in range(solver.maxiter):
+    sol, state = solver.update(sol, state, *args, **kwargs)
+    sols.append(sol)
+    errors.append(state.error)
+  return jnp.stack(sols, axis=0), errors
+
+
+# dummy dataset
+X, y = datasets.make_regression(n_samples=100, n_features=10, random_state=0)
+ridge_regression_grad = jax.grad(objective.ridge_regression)
+
+# gradient step: x - grad_x f(x) with f the cost of learning task
+# the fixed point of this mapping verifies grad_x f(x) = 0
+# i.e the fixed point is an optimum 
+def T(params, eta, l2reg, data):
+  g = ridge_regression_grad(params, l2reg, data)
+  step = tree_scalar_mul(eta, g)
+  return tree_sub(params, step)
+
+w_init = jnp.zeros(X.shape[1])  # null vector
+eta = 1e-1  # small step size
+l2reg = 0.  # no regularization
+aa = AndersonAcceleration(T, history_size=5, maxiter=150, ridge=1e-5, tol=1e-6)
+picard = PicardIteration(T, maxiter=150, tol=1e-6)
+
+aa_sols, aa_errors = run_all(aa, w_init, eta, l2reg, (X, y))
+pi_sols, pi_errors = run_all(picard, w_init, eta, l2reg, (X, y))
+pi_sols = pi_sols[aa.history_size-1:]
+
+sol = aa_sols[-1]
+print(f'Error={aa_errors[-1]:.6f} at parameters {sol}')
+print(f'At this point the gradient {ridge_regression_grad(sol, l2reg, (X,y))} is close to zero vector so we found the minimum.')
+
+fig = plt.figure(figsize=(10, 12))
+fig.suptitle('Trajectory in parameter space')
+spec = fig.add_gridspec(ncols=2, nrows=3, hspace=0.3)
+
+# Plot trajectory in parameter space (8 dimensions)
+for i in range(4):
+  ax = fig.add_subplot(spec[i//2, i%2])
+  ax.plot(pi_sols[:,i], pi_sols[:,2*i+1], '-o', label="Gradient Descent")
+  ax.plot(aa_sols[:,i], aa_sols[:,2*i+1], '-o', label="Anderson Accelerated GD")
+  ax.set_xlabel(f'$x_{{{2*i+1}}}$')
+  ax.set_ylabel(f'$x_{{{2*i+2}}}$')
+  if i == 0:
+    ax.legend(loc='upper left', bbox_to_anchor=(0.75, 1.38),
+              ncol=1, fancybox=True, shadow=True)
+  ax.axis('equal')
+
+# Plot error as function of iteration num 
+ax = fig.add_subplot(spec[2, :])
+iters = jnp.arange(len(aa_errors))
+ax.plot(iters, aa_errors, label='Anderson Accelerated GD Error')
+ax.plot(iters, pi_errors, label='Gradient Descent Error')
+ax.set_xlabel('Iteration num')
+ax.set_ylabel('Error')
+ax.set_yscale('log')
+ax.legend()
+plt.show()
+

--- a/examples/plot_picard_ode.py
+++ b/examples/plot_picard_ode.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+Anderson acceleration in application to Picard–Lindelöf theorem.
+================================================================
+
+Thanks to the `Picard–Lindelöf theorem,
+<https://en.wikipedia.org/wiki/Picard%E2%80%93Lindel%C3%B6f_theorem>`_ we can reduce differential equation solving to fixed point computations and simple integration.
+More precisely consider the ODE:
+
+.. math::
+
+  y'(t)=f(t,y(t))
+
+of some time-dependant dynamic :math:`f:\mathbb{R}\times\mathbb{R}^d\rightarrow\mathbb{R}^d` and initial conditions :math:`y(0)=y_0`.
+Then :math:`y` is the fixed point of the following map:
+
+.. math::
+
+  y(t)=T(y)(t)\mathrel{\mathop:}=y_0+\int_0^t f(s,y(s))\mathrm{d}s
+
+Then we can define the sequence of functions :math:`(\phi_k)` with :math:`\phi_0=0` recursively as follow:
+
+.. math::
+
+  \phi_{k+1}(t)=T(\phi_k)(t)\mathrel{\mathop:}=y_0+\int_0^t f(s,\phi_k(s))\mathrm{d}s
+
+Such sequence converges to the solution of the ODE, i.e., :math:`\lim_{k\rightarrow\infty}\phi_k=y`.  
+  
+In this example we take :math:`f(t,y(t))=1+y(t)^2` with solution :math:`y(t)=\tan{t}`. 
+We used `scipy.integrate.cumtrapz` to perform integration, but any other numerical scheme could have worked.
+"""
+
+
+import jax
+import jax.numpy as jnp
+
+from jaxopt import AndersonAcceleration
+
+from jaxopt import objective
+from jaxopt.tree_util import tree_scalar_mul, tree_sub
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn import datasets
+from matplotlib.pyplot import cm
+import scipy.integrate
+
+jax.config.update("jax_platform_name", "cpu")
+
+
+#Solve y'(t)=1+t^2 differential equation, with solution y(t)=tan(t)
+def f(ti, phi):
+  return 1 + phi ** 2
+
+"""Fixed point iteration in the Picard method.
+See: https://en.wikipedia.org/wiki/Picard%E2%80%93Lindel%C3%B6f_theorem"""
+def T(phi_cur, ti, y0, dx):
+  f_phi = f(ti, phi_cur)
+  phi_next = scipy.integrate.cumtrapz(f_phi, initial=y0, dx=dx)
+  return phi_next
+
+y0 = 0
+num_interpolating_points = 400
+t0 = jnp.array(0.)
+tmax = 0.95 * (jnp.pi / 2) # stop before pi/2 to ensure convergence
+dx = (tmax - t0) / (num_interpolating_points-1)
+phi0 = jnp.zeros(num_interpolating_points)
+ti = np.linspace(t0, tmax, num_interpolating_points)
+
+sols = [phi0]
+aa = AndersonAcceleration(T, history_size=3, maxiter=50, ridge=1e-5, jit=False)
+sol, state = aa.init(phi0, ti, y0, dx)
+sols.append(sol)
+for k in range(aa.maxiter):
+  sol, state = aa.update(phi0, state, ti, y0, dx)
+  sols.append(sol)
+res = sols[-1] - np.tan(ti)
+print(f'Error of {jnp.linalg.norm(res)} with ground truth tan(t)')
+
+
+# vizualize the first 8 iterates to make the figure easier to read
+sols = sols[:8]
+fig = plt.figure(figsize=(8,4))
+ax = fig.add_subplot(1, 1, 1)
+
+colors = cm.plasma(np.linspace(0, 1, len(sols)))
+for k, (sol, c) in enumerate(zip(sols, colors)):
+  desc = rf'$\phi_{k}$' if k > 0 else rf'$\phi_0=0$'
+  ax.plot(ti, sol, '+', c=c, label=desc)
+ax.plot(ti, np.tan(ti), '-', c='green', label=r'$y(t)=\tan{(t)}$ (ground truth)')
+
+ax.legend()
+props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)
+formula = rf'$\phi_{{k+1}}(t)=\phi_0+\int_0^{{{tmax/2:.2f}\pi}} f(t,\phi_{{k}}(t))\mathrm{{d}}t$'
+ax.text(0.42, 0.85, formula, transform=ax.transAxes, fontsize=14, verticalalignment='top', bbox=props)
+fig.suptitle('Anderson acceleration for ODE solving')
+plt.show()

--- a/jaxopt/_src/anderson.py
+++ b/jaxopt/_src/anderson.py
@@ -77,8 +77,9 @@ class AndersonAcceleration(base.IterativeSolver):
     implicit_diff_solve: the linear system solver to use.
     jit: whether to JIT-compile the optimization loop (default: "auto").
     unroll: whether to unroll the optimization loop (default: "auto")
+  
   """
-  fixed_point_fun: Callable = None
+  fixed_point_fun: Callable
   history_size: int = 5
   beta: float = 1.
   maxiter: int = 100
@@ -99,6 +100,7 @@ class AndersonAcceleration(base.IterativeSolver):
            *args,
            **kwargs) -> base.OptStep:
     """Initialize the ``(params, state)`` pair.
+
     Args:
       init_params: initial guess of the fixed point, pytree
       *args: additional positional arguments to be passed to ``fixed_point_fun``.

--- a/jaxopt/_src/objective.py
+++ b/jaxopt/_src/objective.py
@@ -98,6 +98,35 @@ least_squares = LeastSquares()
 least_squares.__doc__ = least_squares.__call__.__doc__
 
 
+def ridge_regression(
+  params: jnp.ndarray,
+  l2reg: float,
+  data: Tuple[jnp.ndarray, jnp.ndarray]) -> float:
+  r"""
+  Ridge regression, i.e L2-regularized least squares.
+
+  .. math::
+
+    \frac{1}{2n} ||XW - y||_2^2 +
+    0.5 \cdot \text{l2reg} \cdot ||W||_2^2
+
+  Args:
+    W: parameters.
+    l2reg: strenght of regularization.
+    data: a tuple ``(X, y)`` where ``X`` is a matrix of shape ``(n_samples,
+      n_features)`` and ``y`` is a vector of shape ``(n_samples,)``.
+  Returns:
+    objective value.
+
+  Example::
+
+    value = ridge_regression(W, l2reg, (X, y))
+  """
+  least_squares = LeastSquares()(params, data)
+  ridge = 0.5 * l2reg * jnp.sum(params ** 2)
+  return least_squares + ridge
+
+
 _logloss_vmap = jax.vmap(loss.multiclass_logistic_loss)
 
 

--- a/jaxopt/_src/picard.py
+++ b/jaxopt/_src/picard.py
@@ -44,7 +44,7 @@ class PicardState(NamedTuple):
 
 @dataclass
 class PicardIteration(base.IterativeSolver):
-  """Multi-dimensional fixed point solver using Picard iterations.
+  """Fixed point solver using Picard iterations.
 
   fixed_point_fun should fulfil Banach fixed-point theorem assumptions.
   Otherwise convergence is not guaranteed.
@@ -66,7 +66,7 @@ class PicardIteration(base.IterativeSolver):
     jit: whether to JIT-compile the optimization loop (default: "auto").
     unroll: whether to unroll the optimization loop (default: "auto")
   """
-  fixed_point_fun: Callable = None
+  fixed_point_fun: Callable
   maxiter: int = 100
   tol: float = 1e-5
   has_aux: bool = False

--- a/jaxopt/objective.py
+++ b/jaxopt/objective.py
@@ -15,6 +15,7 @@
 from jaxopt._src.objective import CompositeLinearFunction
 
 from jaxopt._src.objective import least_squares
+from jaxopt._src.objective import ridge_regression
 
 from jaxopt._src.objective import binary_logreg
 


### PR DESCRIPTION
I added documentation section for Fixed Point iteration solvers, including Picard Iterations and Anderson Acceleration.  
  
Those two features are illustrated with two examples (ODE solving and Gradienty descent speed up) contributing to sphynx-gallery.
