### PR TITLE
fix for tree_vdot for when leaves are not arrays. 

### DIFF
--- a/jaxopt/_src/tree_util.py
+++ b/jaxopt/_src/tree_util.py
@@ -48,9 +48,12 @@ def tree_add_scalar_mul(tree_x, scalar, tree_y):
 _vdot = functools.partial(jnp.vdot, precision=jax.lax.Precision.HIGHEST)
 
 
+def _vdot_safe(a, b):
+  return _vdot(jnp.asarray(a), jnp.asarray(b))
+
 def tree_vdot(tree_x, tree_y):
   """Compute the inner product <tree_x, tree_y>."""
-  vdots = tree_multimap(_vdot, tree_x, tree_y)
+  vdots = tree_multimap(_vdot_safe, tree_x, tree_y)
   return tree_reduce(operator.add, vdots)
 
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -30,6 +30,9 @@ class TreeUtilTest(jtu.JaxTestCase):
     self.tree_A = (rng.randn(20, 10), rng.randn(20))
     self.tree_B = (rng.randn(20, 10), rng.randn(20))
 
+    self.tree_A_dict = (1.0, {"k1": 1.0, "k2": (1.0, 1.0)}, 1.0)
+    self.tree_B_dict = (1.0, {"k1": 2.0, "k2": (3.0, 4.0)}, 5.0)
+
     self.array_A = rng.randn(20)
     self.array_B = rng.randn(20)
 
@@ -85,6 +88,10 @@ class TreeUtilTest(jtu.JaxTestCase):
   def test_tree_vdot(self):
     expected = jnp.vdot(self.array_A, self.array_B)
     got = tree_util.tree_vdot(self.array_A, self.array_B)
+    self.assertAllClose(expected, got)
+
+    expected = 15.0
+    got = tree_util.tree_vdot(self.tree_A_dict, self.tree_B_dict)
     self.assertAllClose(expected, got)
 
     expected = (jnp.vdot(self.tree_A[0], self.tree_B[0]) +


### PR DESCRIPTION
Fixes #44

1. Added a _vdot_safe product for computing tree_vdot (Mathieu's fix)
2. Added new test on pytrees that do not have arrays on leaves