### PR TITLE
clean _autosummary

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,6 +22,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf auto_examples/
+	rm -rf _autosummary/
 
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html


### PR DESCRIPTION
The folder _autosummary/ generated need to be deleted too when cleaning, otherwise old .rst might pollute it.