### PR TITLE
take optional reference signature for implicit diff

### DIFF
--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -141,9 +141,12 @@ class IterativeSolver(Solver):
     run = self._run
 
     if getattr(self, "implicit_diff", True):
-      decorator = idf.custom_root(self.optimality_fun,
-                                  has_aux=True,
-                                  solve=self.implicit_diff_solve)
+      reference_signature_fun = getattr(self, "reference_signature_fun", None)
+      decorator = idf.custom_root(
+          self.optimality_fun,
+          has_aux=True,
+          solve=self.implicit_diff_solve,
+          reference_signature_fun=reference_signature_fun)
       run = decorator(run)
 
     return run(init_params, *args, **kwargs)

--- a/jaxopt/_src/gradient_descent.py
+++ b/jaxopt/_src/gradient_descent.py
@@ -15,6 +15,7 @@
 """Implementation of gradient descent in JAX."""
 
 from typing import Any
+from typing import Callable
 from typing import NamedTuple
 
 from dataclasses import dataclass
@@ -81,3 +82,7 @@ class GradientDescent(ProximalGradient):
   def optimality_fun(self, params, *args, **kwargs):
     """Optimality function mapping compatible with ``@custom_root``."""
     return self._grad_fun(params, *args, **kwargs)
+
+  def __post_init__(self):
+    super().__post_init__()
+    self.reference_signature_fun = self.fun

--- a/jaxopt/_src/implicit_diff.py
+++ b/jaxopt/_src/implicit_diff.py
@@ -211,10 +211,11 @@ def _custom_root(solver_fun, optimality_fun, solve, has_aux):
       if ba_kwargs:
         raise TypeError(
             "keyword arguments to solver_fun could not be resolved to "
-            f"positional arguments based on the signature {signature}. This "
-            "can happen under custom_root if optimality_fun takes catch-all "
-            "**kwargs, or under custom_fixed_point if fixed_point_fun takes "
-            "catch-all **kwargs, both of which are currently unsupported.")
+            "positional arguments based on the signature "
+            f"{optimality_signature}. This can happen under custom_root if "
+            "optimality_fun takes catch-all **kwargs, or under "
+            "custom_fixed_point if fixed_point_fun takes catch-all **kwargs, "
+            "both of which are currently unsupported.")
 
       # Compute VJPs w.r.t. args.
       vjps = root_vjp(optimality_fun=optimality_fun, sol=sol,


### PR DESCRIPTION
Instead of always relying on `optimality_fun` to carry the canonical signature for the solver, accept an optional canonical-signature function in `custom_root` and `custom_fixed_point`.

Check for a corresponding optional attribute on subclasses of `IterativeSolver` when run under implicit diff mode. Use this to indicate that `GradientDescent.fun` has the canonical signature for GD solvers.

Fixes #51 
