### PR TITLE
Add modulo option, simplify init

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,4 +35,6 @@ Examples:
 - :ref:`sphx_glr_auto_examples_implicit_diff_plot_dataset_distillation.py`
 - :ref:`sphx_glr_auto_examples_implicit_diff_ridge_reg_implicit_diff.py`
 - :ref:`sphx_glr_auto_examples_deep_learning_robust_training.py`
-- :ref:`sphx_glr_auto_examples_implicit_diff_sparse_coding.py`
+- :ref:`sphx_glr_auto_examples_fixed_point_plot_anderson_accelerate_gd.py`
+- :ref:`sphx_glr_auto_examples_fixed_point_plot_anderson_wrapper_cd.py`
+- :ref:`sphx_glr_auto_examples_fixed_point_plot_picard_ode.py`

--- a/examples/fixed_point/plot_anderson_wrapper_cd.py
+++ b/examples/fixed_point/plot_anderson_wrapper_cd.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 r"""
-Anderson acceleration of Block coordinate descent
-=================================================
+Anderson acceleration of Block coordinate descent.
+==================================================
 
 Block coordinate descent converges to a fixed point. It can therefore be accelerated with Anderson acceleration.
+
+Here `m` denotes the history size, and `K` the frequency of Anderson updates.
 
 Bertrand, Q. and Massias, M., 2021, March. Anderson acceleration of coordinate descent.
 In International Conference on Artificial Intelligence and Statistics (pp. 1288-1296). PMLR.
@@ -52,7 +54,7 @@ def run_all(solver, w_init, *args, **kwargs):
   return jnp.stack(sols, axis=0), errors
 
 
-X, y = datasets.make_regression(n_samples=10, n_features=8, random_state=0)
+X, y = datasets.make_regression(n_samples=10, n_features=8, random_state=1)
 fun = objective.least_squares  # fun(params, data)
 l1reg = 10.0
 data = (X, y)
@@ -61,16 +63,16 @@ w_init = jnp.zeros(X.shape[1])
 maxiter = 80
 
 bcd = BlockCoordinateDescent(fun, block_prox=prox.prox_lasso, maxiter=maxiter, tol=1e-6)
-history_size = 3
-aa = AndersonWrapper(bcd, history_size=history_size, ridge=1e-4)
+history_size = 5
+aa = AndersonWrapper(bcd, history_size=history_size, mixing_frequency=1, ridge=1e-4)
+aam = AndersonWrapper(bcd, history_size=history_size, mixing_frequency=history_size, ridge=1e-4)
 
 aa_sols, aa_errors = run_all(aa, w_init, hyperparams_prox=l1reg, data=data)
+aam_sols, aam_errors = run_all(aam, w_init, hyperparams_prox=l1reg, data=data)
 bcd_sols, bcd_errors = run_all(bcd, w_init, hyperparams_prox=l1reg, data=data)
 
-bcd_errors = bcd_errors[:-history_size]
-bcd_sols = bcd_sols[:-history_size]
-
-print(f'Error={aa_errors[-1]:.6f} at parameters {aa_sols[-1]} for Anderson')
+print(f'Error={aa_errors[-1]:.6f} at parameters {aa_sols[-1]} for Anderson (m=5, K=1)')
+print(f'Error={aam_errors[-1]:.6f} at parameters {aam_sols[-1]} for Anderson (m=5, K=5)')
 print(f'Error={bcd_errors[-1]:.6f} at parameters {bcd_sols[-1]} for Block CD')
 
 fig = plt.figure(figsize=(10, 12))
@@ -80,8 +82,9 @@ spec = fig.add_gridspec(ncols=2, nrows=3, hspace=0.3)
 # Plot trajectory in parameter space (8 dimensions)
 for i in range(4):
   ax = fig.add_subplot(spec[i//2, i%2])
-  ax.plot(bcd_sols[:,i], bcd_sols[:,2*i+1], '-', label="Coordinate Descent")
-  ax.plot(aa_sols[:,i], aa_sols[:,2*i+1], '-', label="Anderson Accelerated CD")
+  ax.plot(bcd_sols[:,i], bcd_sols[:,2*i+1], '--', label="Coordinate Descent")
+  ax.plot(aa_sols[:,i], aa_sols[:,2*i+1], '--', label="Anderson Accelerated CD (m=5, K=1)")
+  ax.plot(aam_sols[:,i], aam_sols[:,2*i+1], '--', label="Anderson Accelerated CD (m=5, K=5)")
   ax.set_xlabel(f'$x_{{{2*i+1}}}$')
   ax.set_ylabel(f'$x_{{{2*i+2}}}$')
   if i == 0:
@@ -93,7 +96,8 @@ for i in range(4):
 ax = fig.add_subplot(spec[2, :])
 iters = jnp.arange(len(aa_errors))
 ax.plot(iters, bcd_errors, '-o', label='Coordinate Descent Error')
-ax.plot(iters, aa_errors, '-o', label='Anderson Accelerated CD Error')
+ax.plot(iters, aa_errors, '-o', label='Anderson Accelerated CD Error (m=5, K=1)')
+ax.plot(iters, aam_errors, '-o', label='Anderson Accelerated CD Error (m=5, K=5)')
 ax.set_xlabel('Iteration num')
 ax.set_ylabel('Error')
 ax.set_yscale('log')

--- a/jaxopt/_src/fixed_point_iteration.py
+++ b/jaxopt/_src/fixed_point_iteration.py
@@ -30,15 +30,12 @@ from jaxopt._src.tree_util import tree_l2_norm, tree_sub
 
 class FixedPointState(NamedTuple):
   """Named tuple containing state information.
-
   Attributes:
     iter_num: iteration number
-    value: pytree of current estimate of fixed point
     error: residuals of current estimate
     aux: auxiliary output of fixed_point_fun when has_aux=True
   """
   iter_num: int
-  value: Any
   error: float
   aux: Any
 
@@ -46,12 +43,10 @@ class FixedPointState(NamedTuple):
 @dataclass
 class FixedPointIteration(base.IterativeSolver):
   """Fixed point iteration method.
-
   Attributes:
     fixed_point_fun: a function ``fixed_point_fun(x, *args, **kwargs)``
       returning a pytree with the same structure and type as x
-      each leaf must be an array (not a scalar). The function
-      should fulfill the Banach fixed-point theorem's assumptions.
+      The function should fulfill the Banach fixed-point theorem's assumptions.
       Otherwise convergence is not guaranteed.
     maxiter: maximum number of iterations.
     tol: tolerance (stopping criterion)
@@ -65,7 +60,6 @@ class FixedPointIteration(base.IterativeSolver):
     implicit_diff_solve: the linear system solver to use.
     jit: whether to JIT-compile the optimization loop (default: "auto").
     unroll: whether to unroll the optimization loop (default: "auto")
-
   References:
     https://en.wikipedia.org/wiki/Fixed-point_iteration
   """
@@ -84,7 +78,6 @@ class FixedPointIteration(base.IterativeSolver):
            *args,
            **kwargs) -> base.OptStep:
     """Initialize the parameters and state.
-
     Args:
       init_params: initial guess of the fixed point, pytree
       *args: additional positional arguments to be passed to ``optimality_fun``.
@@ -93,7 +86,6 @@ class FixedPointIteration(base.IterativeSolver):
       (params, state)
     """
     state = FixedPointState(iter_num=0,
-                            value=init_params,
                             error=jnp.inf,
                             aux=None)
     return base.OptStep(params=init_params, state=state)
@@ -104,7 +96,6 @@ class FixedPointIteration(base.IterativeSolver):
              *args,
              **kwargs) -> base.OptStep:
     """Performs one iteration of the fixed point iteration method.
-
     Args:
       params: pytree containing the parameters.
       state: named tuple containing the solver state.
@@ -118,7 +109,6 @@ class FixedPointIteration(base.IterativeSolver):
     next_params, aux = self._fun(params, *args, **kwargs)
     error = tree_l2_norm(tree_sub(next_params, params))
     next_state = FixedPointState(iter_num=state.iter_num + 1,
-                                 value=next_params,
                                  error=error,
                                  aux=aux)
     return base.OptStep(params=next_params, state=next_state)

--- a/tests/fixed_point_iteration_test.py
+++ b/tests/fixed_point_iteration_test.py
@@ -46,7 +46,6 @@ class FixedPointIterationTest(jtu.JaxTestCase):
   @parameterized.product(jit=[False,True])
   def test_sin_fixed_point(self, jit):
     """Test convergence for simple polynomials and sin.
-
     Also test the support of pytree in input/output.
     """
     def f(x):  # Another fixed point exists for x[0] : ~1.11
@@ -62,7 +61,6 @@ class FixedPointIterationTest(jtu.JaxTestCase):
 
   def test_cos_fixed_point(self):
     """Test convergence for cos fixed point (non-zero fixed point).
-
     Also test support for additional parameters.
     """
     def f(x, theta):
@@ -150,4 +148,3 @@ if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
   absltest.main(testLoader=jtu.JaxTestLoader())
-


### PR DESCRIPTION
Add Modulo option for both AndersonAcceleration and AndersonWrapper. Simplify their `init()` method by pushing the first iterates in `update()`.

We observe that using `modulo=history_size` instead of `modulo=1` does not decrease dramatically the convergence speed (see examples).