### PR TITLE
Add SGD with Armijo line search

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,6 +39,7 @@ Stochastic
 .. autosummary::
   :toctree: _autosummary
 
+    jaxopt.ArmijoSGD
     jaxopt.OptaxSolver
     jaxopt.PolyakSGD
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.1.1 (development version)
+-----------------------------------
+  
+- :class:`jaxopt.ArmijoSGD`
+  
+  
 Version 0.1 (initial release)
 -----------------------------
 

--- a/docs/stochastic.rst
+++ b/docs/stochastic.rst
@@ -50,6 +50,7 @@ Solvers
 .. autosummary::
   :toctree: _autosummary
 
+    jaxopt.ArmijoSGD
     jaxopt.OptaxSolver
     jaxopt.PolyakSGD
 
@@ -73,7 +74,17 @@ Adaptive solvers
 
 Adaptive solvers update the step size at each iteration dynamically.
 An example is :class:`PolyakSGD <jaxopt.PolyakSGD>`, a solver
-which computes step sizes adaptively using function values.
+which computes step sizes adaptively using function values.  
+  
+Another example is :class:`ArmijoSGD <jaxopt.ArmijoSGD>`, a solver
+that uses an Armijo line search.  
+  
+For convergence guarantees to hold, these two algorithms
+require the interpolation hypothesis to hold:  
+the global optimum over :math:`D` must also be a global optimum 
+for any finite sample of :math:`D`.  
+This is typically achieved by overparametrized models (e.g neural networks)
+in classification tasks with separable classes, or on regression tasks without noise.
 
 Run iterator vs. manual loop
 ----------------------------

--- a/examples/deep_learning/flax_image_classif.py
+++ b/examples/deep_learning/flax_image_classif.py
@@ -26,6 +26,7 @@ import jax
 import jax.numpy as jnp
 
 from jaxopt import loss
+from jaxopt import ArmijoSGD
 from jaxopt import OptaxSolver
 from jaxopt import PolyakSGD
 from jaxopt import tree_util
@@ -44,11 +45,12 @@ flags.DEFINE_float("l2reg", 1e-4, "L2 regularization.")
 flags.DEFINE_float("learning_rate", 0.001, "Learning rate (used in adam).")
 flags.DEFINE_bool("manual_loop", False, "Whether to use a manual training loop.")
 flags.DEFINE_integer("maxiter", 100, "Maximum number of iterations.")
-flags.DEFINE_float("max_stepsize", 0.1, "Maximum step size (used in polyak-sgd).")
-flags.DEFINE_float("momentum", 0.9, "Momentum strength (used in adam, polyak-sgd).")
-flags.DEFINE_enum("solver", "adam", ["adam", "sgd", "polyak-sgd"], "Solver to use.")
+flags.DEFINE_float("aggressiveness", 0.5, "Aggressiveness of line search in armijo-sgd.")
+flags.DEFINE_float("momentum", 0.9, "Momentum strength (used in adam, polyak-sgd, armijo-sgd).")
+flags.DEFINE_float("max_stepsize", 0.1, "Maximum step size (used in polyak-sgd, armijo-sgd).")
 flags.DEFINE_enum("dataset", "mnist", dataset_names, "Dataset to train on.")
 flags.DEFINE_enum("model", "cnn", ["cnn", "mlp"], "Model architecture.")
+flags.DEFINE_enum("solver", "adam", ["adam", "sgd", "polyak-sgd", "armijo-sgd"], "Solver to use.")
 FLAGS = flags.FLAGS
 
 
@@ -158,6 +160,14 @@ def main(argv):
                        momentum=FLAGS.momentum,
                        max_stepsize=FLAGS.max_stepsize,
                        pre_update=print_accuracy)
+
+
+  elif FLAGS.solver == "armijo-sgd":
+    solver = ArmijoSGD(fun=loss_fun, maxiter=FLAGS.maxiter,
+                       aggressiveness=FLAGS.aggressiveness,
+                       momentum=FLAGS.momentum,
+                       max_stepsize=FLAGS.max_stepsize,
+                       pre_update=pre_update)
 
   else:
     raise ValueError("Unknown solver: %s" % FLAGS.solver)

--- a/examples/deep_learning/haiku_image_classif.py
+++ b/examples/deep_learning/haiku_image_classif.py
@@ -28,6 +28,7 @@ import jax
 import jax.numpy as jnp
 
 from jaxopt import loss
+from jaxopt import ArmijoSGD
 from jaxopt import OptaxSolver
 from jaxopt import PolyakSGD
 from jaxopt import tree_util
@@ -46,11 +47,12 @@ flags.DEFINE_float("l2reg", 1e-4, "L2 regularization.")
 flags.DEFINE_float("learning_rate", 0.001, "Learning rate (used in adam).")
 flags.DEFINE_bool("manual_loop", False, "Whether to use a manual training loop.")
 flags.DEFINE_integer("maxiter", 100, "Maximum number of iterations.")
-flags.DEFINE_float("max_stepsize", 0.1, "Maximum step size (used in polyak-sgd).")
-flags.DEFINE_float("momentum", 0.9, "Momentum strength (used in adam, polyak-sgd).")
-flags.DEFINE_enum("solver", "adam", ["adam", "sgd", "polyak-sgd"], "Solver to use.")
+flags.DEFINE_float("max_stepsize", 0.1, "Maximum step size (used in polyak-sgd, armijo-sgd).")
+flags.DEFINE_float("aggressiveness", 0.5, "Aggressiveness of line search in armijo-sgd.")
+flags.DEFINE_float("momentum", 0.9, "Momentum strength (used in adam, polyak-sgd, armijo-sgd).")
 flags.DEFINE_enum("dataset", "mnist", dataset_names, "Dataset to train on.")
 flags.DEFINE_enum("model", "cnn", ["cnn", "mlp"], "Model architecture.")
+flags.DEFINE_enum("solver", "adam", ["adam", "sgd", "polyak-sgd", "armijo-sgd"], "Solver to use.")
 FLAGS = flags.FLAGS
 
 
@@ -154,6 +156,14 @@ def main(argv):
                        momentum=FLAGS.momentum,
                        max_stepsize=FLAGS.max_stepsize,
                        pre_update=print_accuracy)
+
+
+  elif FLAGS.solver == "armijo-sgd":
+    solver = ArmijoSGD(fun=loss_fun, maxiter=FLAGS.maxiter,
+                       aggressiveness=FLAGS.aggressiveness,
+                       momentum=FLAGS.momentum,
+                       max_stepsize=FLAGS.max_stepsize,
+                       pre_update=pre_update)
 
   else:
     raise ValueError("Unknown solver: %s" % FLAGS.solver)

--- a/jaxopt/__init__.py
+++ b/jaxopt/__init__.py
@@ -14,6 +14,7 @@
 
 from jaxopt._src.anderson import AndersonAcceleration
 from jaxopt._src.anderson_wrapper import AndersonWrapper
+from jaxopt._src.armijo_sgd import ArmijoSGD
 from jaxopt._src.bisection import Bisection
 from jaxopt._src.block_cd import BlockCoordinateDescent
 from jaxopt._src.fixed_point_iteration import FixedPointIteration

--- a/jaxopt/_src/armijo_sgd.py
+++ b/jaxopt/_src/armijo_sgd.py
@@ -1,0 +1,324 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SGD solver with Armijo line search."""
+
+from dataclasses import dataclass
+from functools import partial
+
+from typing import Any
+from typing import Callable
+from typing import NamedTuple
+from typing import Optional
+
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+
+from jaxopt.tree_util import tree_add_scalar_mul, tree_l2_norm
+from jaxopt.tree_util import tree_scalar_mul, tree_zeros_like
+from jaxopt.tree_util import tree_add, tree_sub
+from jaxopt._src import base
+from jaxopt._src import loop
+
+
+def wolfe_cond_violated(stepsize, coef, f_cur, f_next, grad_sqnorm):
+  eps = jnp.finfo(f_next.dtype).eps
+  return stepsize * coef * grad_sqnorm > f_cur - f_next + eps
+
+
+def curvature_cond_violated(stepsize, coef, f_cur, f_next, grad_sqnorm):
+  return f_next < f_cur - stepsize * (1.-coef) * grad_sqnorm
+
+
+def armijo_line_search(fun_with_aux, unroll, jit,
+                       goldstein, maxls,
+                       params, f_cur, stepsize, grad,
+                       coef, decrease_factor, increase_factor, max_stepsize,
+                       args, kwargs):
+  """Perform Armijo Line search from starting parameters, stepsize and gradient.
+
+  Args:
+    fun_with_aux: function to minimize.
+    jit: whether to JIT-compile the line search loop (default: "auto").
+    unroll: whether to unroll the line search loop (default: "auto"). 
+    goldstein: boolean, whether to use Goldstein or not.
+    maxls: maximum number of steps.
+    params: current params to optimize.
+    f_cur: value of the loss at ``params``.
+    stepsize: initial guess for stepsize.
+    grad: gradient at ``params``.
+    coef: ``1-agressiveness``.
+    decrease_factor: factor to increase stepsize.
+    increase_factor: factor to decrease stepsize.
+    max_stepsize: upper bound on stepsize.
+    args,kwargs: additionals parameters passed to ``fun_with_aux``.
+
+  Returns:
+    stepsize: stepsize Armijo line search conditions
+    next_params: params after gradient step
+    f_next: loss after gradient step
+  """
+  next_params = tree_add_scalar_mul(params, -stepsize, grad)
+  f_next, _ = fun_with_aux(next_params, *args, **kwargs)
+  grad_sqnorm = tree_l2_norm(grad, squared=True)
+
+  def update_stepsize(t):
+    """Multiply stepsize per factor, return new params and new value."""
+    stepsize, factor = t
+    stepsize = stepsize * factor
+    stepsize = jnp.minimum(stepsize, max_stepsize)
+    next_params = tree_add_scalar_mul(params, -stepsize, grad)
+    f_next, _ = fun_with_aux(next_params, *args, **kwargs)
+    return stepsize, next_params, f_next
+
+  def body_fun(t):
+    stepsize, next_params, f_next, _ = t
+
+    violated = wolfe_cond_violated(stepsize, coef, f_cur, f_next, grad_sqnorm)
+    stepsize, next_params, f_next = lax.cond(violated, update_stepsize,
+                                             lambda _: (stepsize, next_params, f_next),
+                                             operand=(stepsize, decrease_factor))
+
+    if goldstein:
+      goldstein_violated = curvature_cond_violated(stepsize, coef, f_cur, f_next, grad_sqnorm)
+      stepsize, next_params, f_next = lax.cond(goldstein_violated, update_stepsize,
+                                               lambda _: (stepsize, next_params, f_next),
+                                               operand=(stepsize, increase_factor))
+      violated = jnp.logical_or(violated, goldstein_violated)
+
+    return stepsize, next_params, f_next, violated
+
+  init_val = stepsize, next_params, f_next, jnp.array(True)
+  ret = loop.while_loop(cond_fun=lambda t: t[-1],  # check boolean violated
+                        body_fun=body_fun,
+                        init_val=init_val, maxiter=maxls,
+                        unroll=unroll, jit=jit)
+  return ret[:-1]   # remove boolean
+
+
+class ArmijoState(NamedTuple):
+  """Named tuple containing state information.
+
+  Attributes:
+    iter_num: iteration number
+    error: residuals of current estimate
+    value: current value of the loss
+    stepsize: current stepsize
+    velocity: momentum term
+  """
+  iter_num: int
+  error: float
+  value: float
+  aux: Any
+  stepsize: float
+  velocity: Optional[Any]
+
+
+@dataclass
+class ArmijoSGD(base.StochasticSolver):
+  """SGD with Armijo line search.
+
+  This implementation assumes that the interpolation property holds.  
+  In practice this algorithm works well outside this setting.
+
+  Attributes:
+    fun: a function of the form ``fun(params, *args, **kwargs)``, where
+      ``params`` are parameters of the model,
+      ``*args`` and ``**kwargs`` are additional arguments.
+    aggressiveness: controls "agressiveness" of optimizer. (default: 0.9)
+      Bigger values encourage bigger stepsize. Must belong to open interval (0,1).
+      If ``aggressiveness>0.5`` the learning_rate is guaranteed to be at least as big as ``min(1/L, max_stepsize)``
+      where ``L`` is the Lipschitz constant of the loss on the current batch.
+    decrease_factor: factor by which to decrease the stepsize during line search. (default: 0.8)
+    increase_factor: factor by which to increase the stepsize during line search. (default: 1.5)
+    reset_option: strategy to use for resetting the stepsize at each iteration. (default: "increase")  
+        
+      - "conservative": re-use previous stepsize, producing a non increasing sequence of stepsizes. Slow convergence.
+      - "increase": attempt to re-use previous stepsize multiplied by increase_factor. Cheap and efficient heuristic.
+      - "goldstein": re-use previous stepsize and increase until curvature condition is fulfilled.
+        Higher runtime cost than "increase" but better theoretical guarantees.
+    momentum: momentum parameter, 0 corresponding to no momentum.
+    max_stepsize: a maximum step size to use. (default: 1.)
+    pre_update: a function to execute before the solver's update.
+      The function signature must be
+      ``params, state = pre_update(params, state, *args, **kwargs)``.
+    maxiter: maximum number of solver iterations.
+    maxls: maximum number of steps in line search.
+    tol: tolerance to use.
+    verbose: whether to print error on every iteration or not. verbose=True will
+      automatically disable jit.
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled
+      iterations.
+    implicit_diff_solve: the linear system solver to use.
+    has_aux: whether ``fun`` outputs one (False) or more values (True).
+      When True it will be assumed by default that ``fun(...)[0]``
+      is the objective value. The auxiliary outputs are stored in
+      ``state.aux``.
+    jit: whether to JIT-compile the optimization loop (default: "auto").
+    unroll: whether to unroll the optimization loop (default: "auto").
+
+  References:
+    Vaswani, S., Mishkin, A., Laradji, I., Schmidt, M., Gidel, G. and Lacoste-Julien, S., 2019.
+    Painless stochastic gradient: Interpolation, line-search, and convergence rates.
+    Advances in neural information processing systems, 32, pp.3732-3745.
+  """
+  fun: Callable
+  aggressiveness: float = 0.9  # default value recommanded by authors in convex minimization
+  decrease_factor: float = 0.8  # default value recommanded by authors in convex minimization
+  increase_factor: float = 1.5  # default value recommanded by authors in convex minimization
+  reset_option: str = "increase"
+  momentum: float = 0.0
+  max_stepsize: float = 1.0
+  pre_update: Optional[Callable] = None
+  maxiter: int = 500
+  maxls: int = 15
+  tol: float = 1e-3
+  verbose: int = 0
+  implicit_diff: bool = False
+  implicit_diff_solve: Optional[Callable] = None
+  has_aux: bool = False
+  jit: base.AutoOrBoolean = "auto"
+  unroll: base.AutoOrBoolean = "auto"
+
+  def init_state(self, init_params, *args, **kwargs) -> ArmijoState:
+    """Initialize the state.
+
+    Args:
+      init_params: pytree containing the initial parameters.
+      *args: additional positional arguments to be passed to ``fun``.
+      **kwargs: additional keyword arguments to be passed to ``fun``.
+    Returns:
+      state
+    """
+    del args, kwargs  # Not used.
+
+    if self.momentum == 0:
+      velocity = None
+    else:
+      velocity = tree_zeros_like(init_params)
+    
+    state = ArmijoState(iter_num=0,
+                        error=jnp.inf,
+                        value=jnp.inf,
+                        aux=False,
+                        stepsize=jnp.asarray(self.max_stepsize),
+                        velocity=velocity)
+    return state
+
+  def reset_stepsize(self, stepsize):
+    """Return new step size for current step, according to reset_option."""
+    if self.reset_option == 'goldstein':
+      return stepsize
+    if self.reset_option == 'conservative':
+      return stepsize
+    stepsize = stepsize * self.increase_factor
+    return jnp.minimum(stepsize, self.max_stepsize)
+
+  def update(self, params, state, *args, **kwargs) -> base.OptStep:
+    """Performs one iteration of the solver.
+
+    Args:
+      params: pytree containing the parameters.
+      state: named tuple containing the solver state.
+      *args: additional positional arguments to be passed to ``fun``.
+      **kwargs: additional keyword arguments to be passed to ``fun``.
+    Returns:
+      (params, state)
+    """
+    if self.pre_update:
+      params, state = self.pre_update(params, state, *args, **kwargs)
+    
+    stepsize = self.reset_stepsize(state.stepsize)
+
+    (f_cur, aux), grad = self._value_and_grad_with_aux(params, *args, **kwargs)
+    
+    goldstein = self.reset_option == 'goldstein'
+    stepsize, next_params, f_next = self._armijo_line_search(goldstein, self.maxls,
+                                                             params, f_cur, stepsize, grad, self._coef,
+                                                             self.decrease_factor, self.increase_factor,
+                                                             self.max_stepsize, args, kwargs)
+
+    if self.momentum == 0:
+      next_velocity = None
+    else:
+      # next_params = params - stepsize*grad + momentum*(params - previous_params)
+      velocity = tree_scalar_mul(self.momentum, state.velocity)
+      next_params = tree_add(next_params, velocity)
+      next_velocity = tree_sub(next_params, params)
+
+    # error of last step, avoid recomputing a gradient
+    error = tree_l2_norm(grad, squared=False)
+
+    next_state = ArmijoState(iter_num=state.iter_num+1,
+                             error=error,
+                             value=f_next,
+                             aux=state.aux,
+                             stepsize=stepsize,
+                             velocity=next_velocity)
+
+    return base.OptStep(next_params, next_state)
+
+  def optimality_fun(self, params, *args, **kwargs):
+    """Optimality function mapping compatible with ``@custom_root``."""
+    return self._grad_fun(params, *args, **kwargs)
+
+  def _value_and_grad_fun(self, params, *args, **kwargs):
+    (value, aux), grad = self._value_and_grad_with_aux(params, *args, **kwargs)
+    return value, grad
+
+  def _grad_fun(self, params, *args, **kwargs):
+    return self._value_and_grad_fun(params, *args, **kwargs)[1]
+
+  def __post_init__(self):
+    options = ['increase', 'goldstein', 'conservative']
+    if self.reset_option not in options:
+      raise ValueError(f"'reset_option' should be one of {options}")
+    if self.aggressiveness <= 0. or self.aggressiveness >= 1.:
+      raise ValueError(f"'aggressiveness' must belong to open interval (0,1)")
+
+    self._coef = 1 - self.aggressiveness
+
+    if self.has_aux:
+      self._fun = lambda *a, **kw: self.fun(*a, **kw)[0]
+      fun_with_aux = self.fun
+    else:
+      self._fun = self.fun
+      fun_with_aux = lambda *a, **kw: (self.fun(*a, **kw), None)
+
+    self._fun_with_aux = fun_with_aux
+    self._value_and_grad_with_aux = jax.value_and_grad(fun_with_aux,
+                                                       has_aux=True)
+    self.reference_signature = self.fun
+
+    #TODO: avoid code repetition
+
+    if self.jit == "auto":
+      # We always jit unless verbose mode is enabled.
+      jit = not self.verbose
+    else:
+      jit = self.jit
+
+    if self.unroll == "auto":
+      # We unroll when implicit diff is disabled or when jit is disabled.
+      unroll = not getattr(self, "implicit_diff", True) or not jit
+    else:
+      unroll = self.unroll
+
+    armijo_with_fun = partial(armijo_line_search, fun_with_aux, unroll, jit)
+    if jit:
+      jitted_armijo = jax.jit(armijo_with_fun, static_argnums=(0,1))
+      self._armijo_line_search = jitted_armijo
+    else:
+      self._armijo_line_search = armijo_with_fun

--- a/tests/armijo_sgd_test.py
+++ b/tests/armijo_sgd_test.py
@@ -1,0 +1,233 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import itertools
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+
+from jaxopt import objective
+from jaxopt import ArmijoSGD
+from jaxopt._src import test_util
+
+import numpy as onp
+from sklearn import datasets
+
+
+class ArmijoSgdTest(jtu.JaxTestCase):
+
+  @parameterized.product(aggressiveness=[0.1, 0.5, 0.9], decrease_factor=[0.8, 0.9])
+  def test_interpolating_regime(self, aggressiveness, decrease_factor):
+    """Test Armijo on a problem on which interpolation holds.
+
+    No regularization, one cluster per class, two classes, with enough distance,
+    to ensure classes are easily separable.
+    """
+    X, y = datasets.make_classification(n_samples=100, n_features=20, n_classes=2,
+                                        n_informative=10, n_redundant=10,
+                                        n_clusters_per_class=1, class_sep=6.,
+                                        random_state=42)
+    data = (X, y)
+    l2reg = 0.0
+    # fun(params, data)
+    fun = objective.l2_multiclass_logreg_with_intercept
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    pytree_init = (W_init, b_init)
+
+    tol = 1e-5
+    opt = ArmijoSGD(fun=fun, aggressiveness=aggressiveness, decrease_factor=decrease_factor,
+                    maxiter=20*1000, tol=tol)
+    params, state = opt.run(pytree_init, l2reg=l2reg, data=data)
+    loss = opt.fun(params, l2reg, data)
+    self.assertLessEqual(state.error, tol)
+    self.assertLessEqual(loss, tol)  # check interpolation
+    error = opt.l2_optimality_error(params, l2reg=l2reg, data=data)
+    self.assertLessEqual(error, tol)
+
+  @parameterized.product(l2reg=[1e-1, 1])
+  def test_non_interpolating_regime(self, l2reg):
+    """Test Armijo on a problem on which interpolation does not holds.
+
+    No (theoretical) convergence guarantees.
+    """
+    X, y = datasets.make_classification(n_samples=200, n_features=10, n_classes=3,
+                                        n_informative=5, n_redundant=3,
+                                        n_clusters_per_class=2, class_sep=1.,
+                                        random_state=42)
+    data = (X, y)
+    # fun(params, data)
+    fun = objective.l2_multiclass_logreg_with_intercept
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    pytree_init = (W_init, b_init)
+
+    tol = 1e-7
+    opt = ArmijoSGD(fun=fun, aggressiveness=0.7, maxiter=10*1000, tol=tol)
+    params, state = opt.run(pytree_init, l2reg=l2reg, data=data)
+    error = opt.l2_optimality_error(params, l2reg=l2reg, data=data)
+    self.assertLessEqual(error, 1e-3)
+
+  def test_logreg_autodiff(self):
+    X, y = datasets.load_digits(return_X_y=True)
+    data = (X, y)
+    l2reg = float(X.shape[0])
+    fun = objective.l2_multiclass_logreg
+
+    jac_num = test_util.logreg_skl_jac(X, y, l2reg)
+    W_skl = test_util.logreg_skl(X, y, l2reg)
+
+    # Make sure the decorator works.
+    opt = ArmijoSGD(fun=fun, maxiter=5)
+    def wrapper(l2reg):
+      return opt.run(W_skl, l2reg=l2reg, data=data).params
+    jac_custom = jax.jacrev(wrapper)(l2reg)
+    self.assertArraysAllClose(jac_num, jac_custom, atol=1e-2)
+
+  def test_logreg_implicit_diff(self):
+    X, y = datasets.load_digits(return_X_y=True)
+    data = (X, y)
+    l2reg = float(X.shape[0])
+    fun = objective.l2_multiclass_logreg
+
+    jac_num = test_util.logreg_skl_jac(X, y, l2reg)
+    W_skl = test_util.logreg_skl(X, y, l2reg)
+
+    # Make sure the decorator works.
+    opt = ArmijoSGD(fun=fun, maxiter=5)
+    def wrapper(l2reg):
+      # Unfortunately positional arguments are required when implicit_diff=True.
+      return opt.run(W_skl, l2reg, data).params
+    jac_custom = jax.jacrev(wrapper)(l2reg)
+    self.assertArraysAllClose(jac_num, jac_custom, atol=1e-2)
+
+  def test_goldstein(self):
+    X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
+                                        n_informative=3, random_state=0)
+
+    def dataset_loader(X, y, n_iter):
+      rng = onp.random.RandomState(0)
+      for _ in range(n_iter):
+        perm = rng.permutation(len(X))
+        yield X[perm], y[perm]
+
+    l2reg = 10.0
+    fun = objective.l2_multiclass_logreg_with_intercept
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    params = (W_init, b_init)
+
+    tol = 1e-3
+    opt = ArmijoSGD(fun=fun, reset_option='goldstein', maxiter=1000, tol=tol)
+    iterable = dataset_loader(X, y, n_iter=200)
+    state = opt.init_state(params, l2reg=l2reg)
+    @jax.jit
+    def jitted_update(params, state, data):
+      return opt.update(params, state, l2reg=l2reg, data=data)
+    for data in itertools.islice(iterable, 0, opt.maxiter):
+      params, state = jitted_update(params, state, data)
+    # Check optimality conditions.
+    error = opt.l2_optimality_error(params, l2reg=l2reg, data=(X, y))
+    self.assertLessEqual(error, tol)
+
+  def test_run_iterable(self):
+    X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
+                                        n_informative=3, random_state=0)
+
+    def dataset_loader(X, y, n_iter):
+      rng = onp.random.RandomState(0)
+      for _ in range(n_iter):
+        perm = rng.permutation(len(X))
+        yield X[perm], y[perm]
+
+    l2reg = 100.0
+    fun = objective.l2_multiclass_logreg_with_intercept
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    pytree_init = (W_init, b_init)
+
+    tol = 3e-1
+    opt = ArmijoSGD(fun=fun, maxiter=10, tol=tol)  # few iterations due to speed issues
+    iterable = dataset_loader(X, y, n_iter=200)
+    params, _ = opt.run_iterator(pytree_init, iterable, l2reg=l2reg)
+
+    # Check optimality conditions.
+    error = opt.l2_optimality_error(params, l2reg=l2reg, data=(X, y))
+    self.assertLessEqual(error, tol)
+
+  @parameterized.product(momentum=[0.5, 0.9])
+  def test_momentum(self, momentum):
+    X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
+                                        n_informative=3, random_state=0)
+    data = (X, y)
+    l2reg = 100.0
+    # fun(params, data)
+    fun = objective.l2_multiclass_logreg_with_intercept
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    pytree_init = (W_init, b_init)
+
+    opt = ArmijoSGD(fun=fun, momentum=momentum)
+
+    params, state = opt.run(pytree_init, l2reg=l2reg, data=data)
+
+    # Check optimality conditions.
+    error = opt.l2_optimality_error(params, l2reg=l2reg, data=data)
+    self.assertLessEqual(error, 0.05)
+
+
+  def test_logreg_with_intercept_run(self):
+    X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
+                                        n_informative=3, random_state=0)
+    data = (X, y)
+    l2reg = 100.0
+    _fun = objective.l2_multiclass_logreg_with_intercept
+    def fun(params, l2reg, data):
+      return _fun(params, l2reg, data), None
+
+    n_classes = len(jnp.unique(y))
+
+    W_init = jnp.zeros((X.shape[1], n_classes))
+    b_init = jnp.zeros(n_classes)
+    pytree_init = (W_init, b_init)
+
+    opt = ArmijoSGD(fun=fun, maxiter=300, has_aux=True)
+    # Test positional, keyword and mixed arguments.
+    for params, _ in (opt.run(pytree_init, l2reg, data),
+                      opt.run(pytree_init, l2reg=l2reg, data=data),
+                      opt.run(pytree_init, l2reg, data=data)):
+
+      # Check optimality conditions.
+      error = opt.l2_optimality_error(params, l2reg=l2reg, data=data)
+      self.assertLessEqual(error, 0.05)
+
+
+if __name__ == '__main__':
+  # Uncomment the line below in order to run in float64.
+  # jax.config.update("jax_enable_x64", True)
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Add support for Armijo Line Search. Different options for stepsise resetting are available, such as Goldstein Line search.  Add corresponding tests and documentation.

Rename `step_size` into `stepsize` in PolyakSGD for API consistency with `ProximalGradientDescent`.

Add an example in section `stochastic` to compare different Gradient Descent algorithms on simple classification task (under interpolation hypothesis), namely Gradient Descent, Proximal Gradient Descent, PolyakSGD and ArmijoSGD.