### PR TITLE
fixes #70

### DIFF
--- a/jaxopt/_src/projected_gradient.py
+++ b/jaxopt/_src/projected_gradient.py
@@ -129,5 +129,7 @@ class ProjectedGradient(base.IterativeSolver):
                                 decrease_factor=self.decrease_factor,
                                 verbose=self.verbose,
                                 implicit_diff=self.implicit_diff,
-                                has_aux=self.has_aux)
+                                has_aux=self.has_aux,
+                                jit=self.jit,
+                                unroll=self.unroll)
 

--- a/tests/projected_gradient_test.py
+++ b/tests/projected_gradient_test.py
@@ -99,6 +99,21 @@ class ProjectedGradientTest(jtu.JaxTestCase):
     J2 = (solution(0.1 + eps) - solution(0.1 - eps)) / (2 * eps)
     self.assertArraysAllClose(J, J2, atol=1e-2)
 
+  def test_polyhedron_projection(self):
+    def f(x):
+      return x[0]**2-x[1]**2
+
+    A = jnp.array([[0, 0]])
+    b = jnp.array([0])
+    G = jnp.array([[-1, -1], [0, 1], [1, -1], [-1, 0], [0, -1]])
+    h = jnp.array([-1, 1, 1, 0, 0])    
+    hyperparams = (A, b, G, h)
+
+    proj = projection.projection_polyhedron
+    pg = ProjectedGradient(fun=f, projection=proj, jit=False)
+    sol, state = pg.run(init_params=jnp.array([0.,1.]), hyperparams_proj=hyperparams)
+    self.assertLess(state.error, pg.tol)
+
 
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.


### PR DESCRIPTION
`ProjectedGradient` was using `ProximalGradient` under the hood without forwarding `jit,unroll`. Moreover the FISTA line search was automatically jitted, which causes problem with non jittable proximal operators.

This PR uses the same architecture for Line Search than Armijo: the line search code is moved out of the class definition into a function in the global scope. The Line search is jitted once for all in `__post_init__`, so we should expect speed improvements in `run_iterator` or manuals loops using `update()`, bypassing useless recompilations.

