### PR TITLE
Allow Callable in stepsize.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 0.1.2 (development)
+---------------------------
+
+New features
+~~~~~~~~~~~~
+
+- allow ``Callable`` for ``stepsize`` in :class:`jaxopt.ProximalGradient`, :class:`jaxopt.ProjectedGradient`, :class:`jaxopt.GradientDescent`
+
 Version 0.1.1
 -------------
 

--- a/jaxopt/_src/gradient_descent.py
+++ b/jaxopt/_src/gradient_descent.py
@@ -17,6 +17,7 @@
 from typing import Any
 from typing import Callable
 from typing import NamedTuple
+from typing import Union
 
 from dataclasses import dataclass
 
@@ -33,7 +34,8 @@ class GradientDescent(ProximalGradient):
     fun: a smooth function of the form ``fun(parameters, *args, **kwargs)``,
       where ``parameters`` are the model parameters w.r.t. which we minimize
       the function and the rest are fixed auxiliary parameters.
-    stepsize: a stepsize to use (if <= 0, use backtracking line search).
+    stepsize: a stepsize to use (if <= 0, use backtracking line search),
+      or a callable specifying the **positive** stepsize to use at each iteration.
     maxiter: maximum number of proximal gradient descent iterations.
     maxls: maximum number of iterations to use in the line search.
     tol: tolerance to use.

--- a/jaxopt/_src/mirror_descent.py
+++ b/jaxopt/_src/mirror_descent.py
@@ -131,10 +131,14 @@ class MirrorDescent(base.IterativeSolver):
     diff_x = tree_sub(next_x, x)
     return tree_l2_norm(diff_x)
 
+  def _stepsize(self, iter_num):
+    if isinstance(self.stepsize, Callable):
+      return self.stepsize(iter_num)
+    return self.stepsize
+
   def _update(self, x, state, hyperparams_proj, args, kwargs):
     iter_num = state.iter_num
-    stepsize = (self.stepsize(iter_num) if isinstance(self.stepsize, Callable)
-                else self.stepsize)
+    stepsize = self._stepsize(iter_num)
     x_fun_grad, aux = self._grad_with_aux(x, *args, **kwargs)
     next_x = self.projection_grad(x, x_fun_grad, stepsize, hyperparams_proj)
     error = self._error(x, x_fun_grad, hyperparams_proj)

--- a/jaxopt/_src/projected_gradient.py
+++ b/jaxopt/_src/projected_gradient.py
@@ -18,6 +18,7 @@ from typing import Any
 from typing import Callable
 from typing import NamedTuple
 from typing import Optional
+from typing import Union
 
 from dataclasses import dataclass
 
@@ -39,7 +40,8 @@ class ProjectedGradient(base.IterativeSolver):
     projection: projection operator associated with the constraints.
       It should be of the form ``projection(params, hyperparams_proj)``.
       See ``jaxopt.projection`` for examples.
-    stepsize: a stepsize to use (if <= 0, use backtracking line search).
+    stepsize: a stepsize to use (if <= 0, use backtracking line search),
+      or a callable specifying the **positive** stepsize to use at each iteration.
     maxiter: maximum number of projected gradient descent iterations.
     maxls: maximum number of iterations to use in the line search.
     tol: tolerance to use.
@@ -56,7 +58,7 @@ class ProjectedGradient(base.IterativeSolver):
   """
   fun: Callable
   projection: Callable
-  stepsize: float = 0.0
+  stepsize: Union[float, Callable] = 0.0
   maxiter: int = 500
   maxls: int = 15
   tol: float = 1e-3


### PR DESCRIPTION
Add support for `Callable` in `stepsize` for `ProximalGradient`, ``ProjectedGradient`, `GradientDescent` in version `0.1.2`.

Any `Callable` returning **positive** step sizes can be used. However there is no support for negative step size (i.e switching dynamically to line search during training) since it produces a different execution path. The only solution would be to use `lax.cond`. Unfortunately this instruction requires the two branches to be jittable, which causes problem for non jittable proximal operators.  
  
I think it is better to keep it this way for now. If a user wants to alternate between line search and custom stepsize schedule, he can instanciate two `ProximalGradient` objects with different parameters and call their `update()` method.
