### PR TITLE
Add OSQP Jax implementation + tests.

### DIFF
--- a/jaxopt/_src/linear_operator.py
+++ b/jaxopt/_src/linear_operator.py
@@ -1,0 +1,80 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interface for linear operators."""
+
+import functools
+import jax
+import jax.numpy as jnp
+import numpy as onp
+
+from jaxopt.tree_util import tree_map, tree_sum, tree_mul
+
+
+class DenseLinearOperator:
+
+  def __init__(self, pytree):
+    self.pytree = pytree
+
+  def __call__(self, x):
+    return self.matvec(x)
+
+  def matvec(self, x):
+    return tree_map(jnp.dot, self.pytree, x)
+
+  def rmatvec(self, _, y):
+    return tree_map(lambda w,yi: jnp.dot(w.T, yi), self.pytree, y)
+
+  def matvec_and_rmatvec(self, x, y):
+    return self.matvec(x), self.rmatvec(x, y)
+
+  def normal_matvec(self, x):
+    """Computes A^T A x from matvec(x) = A x, where A is square."""
+    return self.rmatvec(x, self.matvec(x))
+
+  def diag(self):
+    diags_only = tree_map(jnp.diag, self.pytree)
+    return diags_only
+
+  def columns_l2_norms(self, squared=False):
+    def col_norm(w):
+      col_norms = jnp.sum(jnp.square(w), axis=0)
+      if not squared:
+        col_norms = jnp.sqrt(col_norms)
+      return col_norms
+    return tree_map(col_norm, self.pytree)
+
+
+class FunctionalLinearOperator:
+
+  def __init__(self, fun, params):
+    self.fun = functools.partial(fun, params)
+
+  def __call__(self, x):
+    return self.matvec(x)
+
+  def matvec(self, x):
+    return self.fun(x)
+
+  def rmatvec(self, x, y):
+    return self.matvec_and_rmatvec(x, y)[1]
+
+  def matvec_and_rmatvec(self, x, y):
+    matvec_x, vjp = jax.vjp(self.matvec, x)
+    rmatvec_y, = vjp(y)
+    return matvec_x, rmatvec_y
+
+  def normal_matvec(self, x):
+    """Computes A^T A x from matvec(x) = A x, where A is square."""
+    matvec_x, vjp = jax.vjp(self.matvec, x)
+    return vjp(matvec_x)[0]

--- a/jaxopt/_src/osqp.py
+++ b/jaxopt/_src/osqp.py
@@ -1,0 +1,601 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GPU-friendly implementation of OSQP."""
+from abc import ABC, abstractmethod
+
+from typing import Any
+from typing import Callable
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+
+from dataclasses import dataclass
+from functools import partial
+
+import jax
+import jax.nn as nn
+import jax.numpy as jnp
+from jax.tree_util import tree_reduce
+
+from jaxopt._src import base
+from jaxopt._src import implicit_diff as idf
+from jaxopt._src.tree_util import tree_add, tree_sub, tree_mul, tree_div 
+from jaxopt._src.tree_util import tree_scalar_mul, tree_add_scalar_mul, tree_mean
+from jaxopt._src.tree_util import tree_map, tree_vdot, tree_l2_norm, tree_inf_norm
+from jaxopt._src.tree_util import tree_ones_like, tree_zeros_like, tree_where
+from jaxopt._src.tree_util import tree_reciproqual, tree_negative
+from jaxopt._src.linear_operator import DenseLinearOperator, FunctionalLinearOperator
+from jaxopt._src.linear_solve import solve_cg
+from jaxopt._src.quadratic_prog import _matvec_and_rmatvec
+from jaxopt.projection import projection_box
+from jaxopt import loop
+
+
+def _make_osqp_optimality_fun(matvec_Q, matvec_A):
+  """Makes the optimality function for OSQP.
+
+  Returns:
+    optimality_fun(params, params_obj, params_eq, params_ineq) where
+      params = (primal_var, eq_dual_var, ineq_dual_var)
+      params_obj = (P, c)
+      params_eq = A
+      params_ineq = (l, u)
+  """
+  def obj_fun(primal_var, params_obj):
+    x, _ = primal_var
+    params_Q, c = params_obj
+    Q = matvec_Q(params_Q)
+    # minimize 0.5 x^T Q x + c^T x
+    qp_obj = tree_add_scalar_mul(tree_vdot(c, x), 0.5, tree_vdot(x, Q(x)))
+    return qp_obj
+
+  def eq_fun(primal_var, params_eq):
+    # constraint Ax=z associated to y^T(Ax-z)=0
+    x, z = primal_var
+    A = matvec_A(params_eq)
+    z_bar = A(x)
+    return tree_sub(z_bar, z)
+
+  def ineq_fun(primal_var, params_ineq):
+    # constraints l<=z<=u associated to mu^T(z-u) + phi^T(l-z)
+    _, z = primal_var
+    l, u = params_ineq
+    # if l=-inf (resp. u=+inf) then phi (resp. mu)
+    # will be zero (never active at infinity)
+    # so we may set the residual l-z (resp. z-u) to zero too.
+    # since 0 * inf = 0 here.
+    # but not in IEEE 754 standard where 0 * inf = nan.
+    # Note: the derivative in +inf or -inf does not make sense anyway,
+    # but those terms need to be computed since they are part of Lagrangian.
+    u_inf = tree_map(lambda ui: ui != jnp.inf, u)
+    l_inf = tree_map(lambda li: li != -jnp.inf, l)
+    upper = tree_where(u_inf, tree_sub(z, u), 0)  # mu in dual
+    lower = tree_where(l_inf, tree_sub(l, z), 0)  # phi in dual
+    return upper, lower
+  
+  return idf.make_kkt_optimality_fun(obj_fun, eq_fun, ineq_fun)
+
+
+class OSQPState(NamedTuple):
+  """Named tuple containing state information.
+
+  Attributes:
+    iter_num: iteration number
+    error: error used as stop criterion, deduced from residuals
+    status: integer, one of ``[OSQP.UNSOLVED, OSQP.SOLVED, OSQP.PRIMAL_INFEASIBLE, OSQP.DUAL_INFEASIBLE]``.
+    primal_residuals: residuals of constraints of primal problem
+    dual_residuals: residuals of constraints of dual problem
+    rho_bar: current stepsize.
+    eq_qp_last_sol: solution of equality constrained QP. Useful for warm start.
+    params_precond: parameters for preconditioner of equality constrained QP.
+  """
+  iter_num: int
+  error: float
+  status: int
+  primal_residuals: Any
+  dual_residuals: Any
+  rho_bar: Any
+  eq_qp_last_sol: Tuple[Any, Any]
+  params_precond: Any
+
+
+def _make_linear_operator(matvec):
+  if matvec is None:
+    return DenseLinearOperator
+  else:
+    return partial(FunctionalLinearOperator, matvec)
+
+
+@dataclass
+class OSQPPreconditioner(ABC):
+  """Abstract class for OSQP preconditioners.
+  
+  Must approximate the inverse of Mx = Px + sigma x + rho_bar A^T A x.
+  
+  Attributes:
+    matvec_Q: (optional) a Callable matvec_Q(params_Q, x).
+    matvec_A: (optional) a Callable matvec_A(params_A, x).
+  """
+  matvec_Q: Optional[Callable] = None
+  matvec_A: Optional[Callable] = None
+
+  @abstractmethod
+  def __call__(self, precond_params, x):
+    """Computes M^{-1}x."""
+    pass
+  
+  @abstractmethod
+  def init_params_precond(self, params_Q, params_A, sigma, rho_bar):
+    """Get initial parameters for preconditioner."""
+    pass
+
+  @abstractmethod
+  def update_stepsize(self, precond_params, rho_bar):
+    """Update preconditioner parameters when rho_bar changes; should be efficient."""
+    pass
+
+
+class NoPreconditioner(OSQPPreconditioner):
+  """Dummy class for no-preconditioning."""
+
+  def __call__(self, params_precond, x):
+    return x
+  
+  def init_params_precond(self, params_Q, params_A, sigma, rho_bar):
+    return None
+
+  def update_stepsize(self, params_precond, rho_bar):
+    return None
+
+
+class JacobiPreconditioner(OSQPPreconditioner):
+  """Jacobi preconditioner (only available for pytree of matrices)."""
+
+  def __call__(self, params_precond, x):
+    precond_Q, precond_A, sigma, rho_bar = params_precond
+    diag_precond = tree_add_scalar_mul(precond_Q, rho_bar, precond_A)
+    diag_precond = tree_add(diag_precond, sigma)
+    inv_diag = tree_map(lambda m_diag: 1/m_diag, diag_precond)
+    return tree_mul(inv_diag, x)
+
+  def init_params_precond(self, params_Q, params_A, sigma, rho_bar):
+    precond_Q = DenseLinearOperator(params_Q).diag()
+    precond_A = DenseLinearOperator(params_A).columns_l2_norms(squared=True)
+    return precond_Q, precond_A, sigma, rho_bar
+
+  def update_stepsize(self, params_precond, rho_bar):
+    return params_precond[:-1] + (rho_bar,)
+
+
+@dataclass
+class OSQP(base.IterativeSolver):
+  """Operator Splitting Solver for Quadratic Programs.
+
+  Jax implementation of the celebrated GPU-OSQP [1,3] based on ADMM.
+
+  It solves convex problems of the form::
+  
+    \begin{aligned}
+      \min_{x,z} \quad & \frac{1}{2}xQx + c^Tx\\
+      \textrm{s.t.} \quad & Ax=z\\
+        &l\leq z\leq u    \\
+    \end{aligned}
+  
+  Equality constraints are obtained by setting l = u.
+  If the inequality is one-sided then ``jnp.inf can be used for u,
+  and ``-jnp.inf`` for l.
+
+  P must be a positive semidefinite (PSD) matrix.
+
+  The Lagrangian is given by::
+
+    \mathcal{L} = \frac{1}{2}x^TQx + c^Tx + y^T(Ax-z) + mu^T (z-u) + phi^T (l-z)
+
+  Primal variables: x, z
+  Dual variables  : y, mu, phi
+
+  ADMM computes y at each iteration. mu and phi can be deduced from z and y.
+  Defaults values for hyper-parameters come from: https://github.com/osqp/osqp/blob/master/include/constants.h
+
+  Attributes:
+    matvec_Q: (optional) a Callable matvec_Q(params_Q, x).
+      By default, matvec_Q(P, x) = tree_dot(P, x), where the pytree P = params_Q matches x structure.
+    matvec_A: (optional) a Callable matvec_A(params_A, x).
+      By default, matvec_A(A, x) = tree_dot(A, x), where tree pytree A = params_A matches x structure.
+    check_primal_dual_infeasability: if True populates the ``status`` field of ``state``
+      with one of ``OSQP.PRIMAL_INFEASIBLE``, ``OSQP.DUAL_INFEASIBLE``.
+      If False it improves speed but does not check feasability.
+      If the problem is primal or dual infeasible, and jit=False, then a ValueError exception is raised.
+      If "auto", it will be True if jit=False and False otherwise. (default: "auto")
+    sigma: ridge regularization parameter in linear system.
+    momentum: relaxation parameter (default: 1.6), must belong to the open interval (0,2).
+      momentum=1 => no relaxation.
+      momentum<1 => under-relaxation.
+      momentum>1 => over-relaxation.
+      Boyd [2, p21] suggests chosing momentum in [1.5, 1.8].
+    eq_qp_preconditioner: (optional) a string specifying the pre-conditioner (default: None).
+    eq_qp_solve_tol: tolerance for linear solver in equality constrained QP. (default: 1e-5)
+      High tolerance may speedup each ADMM step but will slow down overall convergence. 
+    eq_qp_solve_maxiter: number of iterations for linear solver in equality constrained QP. (default: None)
+      Low maxiter will speedup each ADMM step but may slow down overall convergence.
+    rho_start: initial learning rate. (default: 1e-1)
+    rho_min: minimum learning rate. (default: 1e-6)
+    rho_max: maximum learning rate. (default: 1e6)
+    stepsize_updates_frequency: frequency of stepsize updates. (default: 10).
+      One every `stepsize_updates_frequency` updates computes a new stepsize.
+    primal_infeasible_tol: relative tolerance for primal infeasability detection. (default: 1e-4)
+    dual_infeasible_tol: relative tolerance for dual infeasability detection. (default: 1e-4)
+    maxiter: maximum number of iterations.  (default: 4000)
+    tol: absolute tolerance for stoping criterion (default: 1e-3).
+    termination_check_frequency: frequency of termination check. (default: 5).
+      One every `termination_check_frequency` the error is computed.
+    verbose: If verbose=1, print error at each iteration. If verbose=2, also print stepsizes and primal/dual variables.
+      Warning: verbose>0 will automatically disable jit.
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled iterations.
+    implicit_diff_solve: the linear system solver to use.
+    jit: whether to JIT-compile the optimization loop (default: "auto").
+    unroll: whether to unroll the optimization loop (default: "auto")
+
+  [1] Stellato, B., Banjac, G., Goulart, P., Bemporad, A. and Boyd, S., 2020.
+  OSQP: An operator splitting solver for quadratic programs.
+  Mathematical Programming Computation, 12(4), pp.637-672.
+
+  [2] Boyd, S., Parikh, N., Chu, E., Peleato, B. and Eckstein, J., 2010.
+  Distributed Optimization and Statistical Learning via the Alternating Direction Method of Multipliers.
+  Machine Learning, 3(1), pp.1-122.
+
+  [3] Schubiger, M., Banjac, G. and Lygeros, J., 2020.
+  GPU acceleration of ADMM for large-scale quadratic programming.
+  Journal of Parallel and Distributed Computing, 144, pp.55-67.
+  """
+  matvec_Q: Optional[Callable] = None
+  matvec_A: Optional[Callable] = None
+  check_primal_dual_infeasability: base.AutoOrBoolean = "auto"
+  sigma: float = 1e-6
+  momentum: float = 1.6
+  eq_qp_preconditioner: Optional[str] = None
+  eq_qp_solve_tol: float = 1e-7
+  eq_qp_solve_maxiter: Optional[int] = None
+  rho_start: float = 0.1
+  rho_min: float = 1e-6
+  rho_max: float = 1e6
+  stepsize_updates_frequency: int = 10
+  primal_infeasible_tol: float = 1e-4
+  dual_infeasible_tol: float = 1e-4
+  maxiter: int = 4000
+  tol: float = 1e-3
+  termination_check_frequency: int = 5
+  verbose: int = 0
+  implicit_diff: bool = True
+  implicit_diff_solve: Optional[Callable] = None
+  jit: base.AutoOrBoolean = "auto"
+  unroll: base.AutoOrBoolean = "auto"
+
+
+  # class attributes (ignored by @dataclass)
+  UNSOLVED          = 0  # stopping criterion not reached yet.
+  SOLVED            = 1  # feasible solution found with satisfying precision.
+  DUAL_INFEASIBLE   = 2  # infeasible dual (infeasible primal or unbounded primal).
+  PRIMAL_INFEASIBLE = 3  # infeasible primal.
+
+  def init_state(self, init_params, params_obj, params_eq, params_ineq):
+    x, z = init_params.primal
+    y    = init_params.dual_eq
+    Q    = self.matvec_Q(params_obj[0])
+    c    = params_obj[1]
+    A    = self.matvec_A(params_eq)
+
+    primal_residuals, dual_residuals = self._compute_residuals(Q, c, A, x, z, y)
+    params_precond = self._eq_qp_preconditioner_impl.init_params_precond(params_obj[0], params_obj[1],
+                                                                         self.sigma, self.rho_start)
+
+    return OSQPState(iter_num=0,
+                     error=jnp.inf,
+                     status=OSQP.UNSOLVED,
+                     primal_residuals=primal_residuals,
+                     dual_residuals=dual_residuals,
+                     rho_bar=self.rho_start,
+                     eq_qp_last_sol=x,
+                     params_precond=params_precond)
+  
+  def init_params(self, init_x, params_obj, params_eq, params_ineq):
+    """Return defaults params for initialization."""
+    if init_x is None:
+      init_x = tree_zeros_like(params_obj[1])
+    init_z = self.matvec_A(params_eq)(init_x)
+    init_y = tree_zeros_like(init_z)
+    return base.KKTSolution((init_x, init_z), init_y, (init_y, init_y))
+
+  def _get_full_KKT_solution(primal, y):
+    """Returns all dual variables of the problem."""
+    # Unfortunately OSQP algorithm only returns y as dual variable,
+    # mu and phi are missing, but can be recovered:
+    #
+    # We distinguish between l=u and l<u.
+    # If l<u there are three cases:
+    #   1. l < z < u: phi=0  mu=0 (and y=0)
+    #   2. l = z < u: phi=-y mu=0 (and y<0)
+    #   3. l < z = u: phi=0  mu=y (and y>0)
+    #  this can be simplified with mu=relu(y) and phi=relu(-y)
+    # If l=u then y=mu-phi then we have one degree of liberty to chose mu and phi
+    # by symmetry with previous case we may chose mu=relu(y) and phi=relu(-y).
+    is_pos = tree_map(lambda yi: yi >= 0, y)
+    mu  = tree_where(is_pos, y, 0)  # derivative = 1 in y = 0
+    phi = tree_map(lambda yi: jax.nn.relu(-yi), y)  # derivative = 0 in y = 0
+    # y = mu - phi
+    # d_y = d_mu - d_phi = 1 (everywhere; including in zero)
+    return base.KKTSolution(primal=primal, dual_eq=y, dual_ineq=(mu, phi))
+
+  def _update_stepsize(self, rho_bar, params_precond, primal_residuals, dual_residuals, Q, c, A, x, y):
+    """Update stepsize based on the ratio between primal and dual residuals."""
+    Ax, ATy     = A.matvec_and_rmatvec(x, y)
+    primal_coef = tree_inf_norm(primal_residuals) / tree_inf_norm(Ax)
+    max_inf     = jnp.maximum(tree_inf_norm(Q(x)), jnp.maximum(tree_inf_norm(ATy), tree_inf_norm(c)))
+    dual_coef   = tree_inf_norm(dual_residuals) / max_inf
+    eps_div     = jnp.finfo(dual_coef.dtype).eps
+    coef        = jnp.sqrt(primal_coef / (dual_coef + eps_div))
+    rho_bar     = jnp.clip(rho_bar * coef, self.rho_min, self.rho_max)
+    params_precond = self._eq_qp_preconditioner_impl.update_stepsize(params_precond, rho_bar)
+    return rho_bar, params_precond
+
+  def _compute_residuals(self, Q, c, A, x, z, y):
+    """Compute residuals of constraints for primal and dual, as defined in paper."""
+    Ax, ATy = A.matvec_and_rmatvec(x, y)
+    primal_residuals = tree_sub(Ax, z)
+    dual_residuals = tree_add(tree_add(Q(x), c), ATy)
+    return primal_residuals, dual_residuals
+
+  def _compute_error(self, primal_residuals, dual_residuals):
+    """Return error based on primal/dual residuals."""
+    primal_res_inf = tree_inf_norm(primal_residuals)
+    dual_res_inf = tree_inf_norm(dual_residuals)
+    criterion = jnp.maximum(primal_res_inf, dual_res_inf)
+    status = jnp.where(criterion <= self.tol, OSQP.SOLVED, OSQP.UNSOLVED)
+    return criterion, status
+
+  def _check_dual_infeasability(self, error, status, delta_x, Q, c, Adx, l, u):
+    criterion  = self.dual_infeasible_tol * tree_inf_norm(delta_x)
+
+    certif_Q   = tree_inf_norm(Q(delta_x))
+    certif_c   = tree_vdot(c, delta_x)
+
+    unbouned_l = tree_map(lambda li: li == -jnp.inf, l)
+    unbouned_u = tree_map(lambda ui: ui == jnp.inf, u)
+    certif_l   = tree_map(lambda adxi,li: jnp.all(li <= adxi), Adx, tree_where(unbouned_l, -jnp.inf, -criterion))
+    certif_u   = tree_map(lambda adxi,ui: jnp.all(adxi <= ui), Adx, tree_where(unbouned_u, jnp.inf, criterion))
+    certif_A   = tree_reduce(jnp.logical_and, tree_map(jnp.logical_and, certif_l, certif_u))
+
+    certif_dual_infeasible = jnp.logical_and(jnp.logical_and(certif_Q <= criterion, certif_c <= criterion), certif_A)
+
+    if self.verbose >= 2:
+      print(f"certif_Q={certif_Q} certif_c={certif_c} certif_A={certif_A} criterion={criterion}, Adx={Adx}, certif_l={certif_l}, certif_u={certif_u}")
+
+    # infeasible dual implies either infeasible primal, either unbounded primal.
+    return jax.lax.cond(certif_dual_infeasible,
+      lambda _: (0., OSQP.DUAL_INFEASIBLE),  # dual unfeasible; exit the main loop with error = 0.
+      lambda _: (error, status),
+      operand=None)
+
+  def _check_primal_infeasability(self, error, status, delta_y, ATdy, l, u):
+    criterion = self.primal_infeasible_tol * tree_inf_norm(delta_y)
+    certif_A  = tree_inf_norm(ATdy)
+    bounded_l = tree_where(tree_map(lambda li: li == -jnp.inf, l), 0., l)  # replace inf bounds by zero
+    bounded_u = tree_where(tree_map(lambda ui: ui == jnp.inf, u), 0., u)
+    dy_plus   = tree_map(jax.nn.relu, delta_y)
+    dy_minus  = tree_negative(tree_map(jax.nn.relu, tree_negative(delta_y)))
+    certif_lu = tree_add(tree_vdot(bounded_l, dy_minus), tree_vdot(bounded_u, dy_plus))
+    certif_primal_infeasible = jnp.logical_and(certif_A  <= criterion, certif_lu  <= criterion)
+
+    if self.verbose >= 2:
+      print(f"certif_A={certif_A}, certif_lu={certif_lu}, criterion={criterion}")
+
+    return jax.lax.cond(certif_primal_infeasible,
+      lambda _: (0.,  # primal unfeasible; exit the main loop with error = 0.
+                OSQP.PRIMAL_INFEASIBLE),  
+      lambda _: (error, status),  # primal feasible or unbounded (depends of dual feasability).
+      operand=None)  
+
+  def _check_infeasability(self, prev_sol, sol, error, status, Q, c, A, l, u):
+    delta_x = tree_sub(sol.primal[0], prev_sol.primal[0])
+    delta_y = tree_sub(sol.dual_eq, prev_sol.dual_eq)
+    Adx, ATdy = A.matvec_and_rmatvec(delta_x, delta_y)
+
+    error, status = self._check_dual_infeasability(error, status, delta_x, Q, c, Adx, l, u)
+    error, status = self._check_primal_infeasability(error, status, delta_y, ATdy, l, u)
+
+    jit, _ = self._get_loop_options()
+    if not jit:
+      if status == OSQP.PRIMAL_INFEASIBLE:
+        raise ValueError(f"Primal infeasible. Certificate: y(t+1)-y(t) = {delta_y}.")
+      if status == OSQP.DUAL_INFEASIBLE:
+        raise ValueError(f"Dual infeasible. Certificate: x(t+1)-x(t) = {delta_x}.")
+
+    return error, status
+
+  def _check_termination_conditions(self, primal_residuals, dual_residuals,
+                                    old_params, params, Q, c, A, l, u):
+    error, status = self._compute_error(primal_residuals, dual_residuals)
+    if self.check_primal_dual_infeasability:
+      error, status = self._check_infeasability(old_params, params, error, status, Q, c, A, l, u)
+    return error, status
+
+  def _solve_linear_system(self, params, Q, c, A, rho_bar, state):
+    """ Solve equality constrained QP in ADMM split."""
+    # solve the "augmented" equality constrained QP:
+    #
+    #     minimize 0.5x_bar Q x_bar + c x_bar 
+    #     (1)        + (sigma/2) \|x_bar - x\|^2_2
+    #     (2)        + (rho/2)   \|z_bar - z + rho^{-1} y\|^2_2
+    #     under    A x_bar = z_bar; x_bar = x
+    #
+    #        (1) and (2) come from the augmented Lagrangian
+    #
+    # This problem is easy to solve by writing the KKT optimality conditions.
+    # By construction the solution is unique without imposing strict convexity of objective nor 
+    # independance of the constraints.
+    # The primal feasability conditions are used to eliminate z_bar from the system (which simplifies it).
+    # Note that here we use rho_bar: we do not make use of per-constraint learning rate.
+    x, z = params.primal
+    y    = params.dual_eq  # dual variables for constraints z_bar = z;
+
+    def matvec(x_bar):
+      Qx_sigmax = tree_add_scalar_mul(Q(x_bar), self.sigma, x_bar)
+      ATAx = A.normal_matvec(x_bar)
+      return tree_add_scalar_mul(Qx_sigmax, rho_bar, ATAx)
+    
+    bxq = tree_sub(tree_scalar_mul(self.sigma, x), c)
+    byz = tree_add_scalar_mul(y, -rho_bar, z)
+    b = tree_sub(bxq, A.rmatvec(bxq, byz))
+
+    primal_res_inf = tree_inf_norm(state.primal_residuals)
+    dual_res_inf = tree_inf_norm(state.dual_residuals)
+    atol = 0.15 * jnp.sqrt(primal_res_inf * dual_res_inf)
+    # 0.15 < 1 implies that atol is slower than geometric mean of primal_res_inf and dual_res_inf.
+
+    x_bar = solve_cg(matvec, b,
+                     init=state.eq_qp_last_sol,
+                     M=lambda x: self._eq_qp_preconditioner_impl(state.params_precond, x),
+                     maxiter=self.eq_qp_solve_maxiter,
+                     atol=atol,
+                     tol=self.eq_qp_solve_tol * self.tol)  # adaptive threshold.
+    
+    return x_bar
+
+  def _admm_step(self, params, Q, c, A, box, rho_bar, state):
+    """Performs one atomic step of the ADMM algorithm."""
+    x, z = params.primal
+    y    = params.dual_eq  # dual variables for constraints z_bar = z;
+    # mu, phi = params.dual_ineq are unused
+
+    # lines are numbered according to the pseudo-code in the paper OSQP: https://arxiv.org/pdf/1711.08013.pdf
+
+    # line 3: optimization step for (x_bar, z_bar)
+    # this equality constrained QP is solved by writing KKT conditions
+    # which reduce to a well-posed linear system.
+    x_bar = self._solve_linear_system(params, Q, c, A, rho_bar, state)
+    z_bar = A(x_bar)  # line 4
+
+    # line 5: optimization step for x with relaxation parameter momentum (smooth updates)
+    x_next = tree_add(x, tree_scalar_mul(self.momentum, tree_sub(x_bar, x)))
+
+    # line 6: optimization step for z with relaxation parameter momentum (smooth updates)
+    # by definition A x_bar = z_bar and l <= z <= u thanks to projection
+    # the dual variable y corresponds to constraint z_bar = z
+    z_momentum = tree_add(z, tree_scalar_mul(self.momentum, tree_sub(z_bar, z)))
+    z_step = tree_scalar_mul(1/rho_bar, y)
+    z_free = tree_add(z_momentum, z_step)
+    z_next = projection_box(z_free, box)
+
+    # line 7: gradient descent on dual variables, with relaxation
+    y_step = tree_sub(z_momentum, z_next)
+    y_next = tree_add(y, tree_scalar_mul(rho_bar, y_step))
+
+    return (x_next, z_next), y_next, x_bar
+
+  def update(self, params, state, params_obj, params_eq, params_ineq):
+    """Perform OSQP step."""
+    # The original problem on variables (x,z) is split into TWO problems
+    # with variables (x, z) and (x_bar, z_bar)
+    # 
+    # (x_bar, z_bar) is NOT part of the state because it is recomputed at each step:
+    #    (x_bar, z_bar) = argmin_{x_bar, z_bar} L(x_bar, z_bar, x, z, y)
+    # with L the augmented Lagrangian
+    # z_bar is always such that A x_bar = z_bar
+    #
+    # x = argmin_x L(x_bar, z_bar, x, z, y)
+    # for equality constraint x = x_bar the dual variable is constant (=0) and can be eliminated
+    #
+    # z = argmin_z L(x_bar, z_bar, x, z, y)
+    # for equality constraint z = z_bar the associated dual variable is y
+    Q    = self.matvec_Q(params_obj[0])
+    c    = params_obj[1]
+    A    = self.matvec_A(params_eq)
+    l, u = params_ineq
+
+    # for active constraints (in particular equality constraints) high stepsize is better
+    rho_bar = state.rho_bar
+    if self.verbose >= 2:
+      print(f"rho_bar={rho_bar}")
+
+    (x, z), y, eq_qp_last_sol = self._admm_step(params, Q, c, A, (l, u), rho_bar, state)
+    if self.verbose >= 3:
+      print(f"x={x}\nz={z}\ny={y}")
+
+    primal_residuals, dual_residuals = self._compute_residuals(Q, c, A, x, z, y)
+    if self.verbose >= 3:
+      print(f"primal_residuals={primal_residuals}, dual_residuals={dual_residuals}")
+
+    rho_bar, params_precond = jax.lax.cond(jnp.mod(state.iter_num, self.stepsize_updates_frequency) == 0,
+      lambda _: self._update_stepsize(rho_bar, state.params_precond, primal_residuals, dual_residuals, Q, c, A, x, y),
+      lambda _: (rho_bar, state.params_precond), operand=None)
+
+    sol = OSQP._get_full_KKT_solution(primal=(x, z), y=y)
+
+    error, status = jax.lax.cond(jnp.mod(state.iter_num, self.termination_check_frequency) == 0,
+      lambda _: self._check_termination_conditions(primal_residuals, dual_residuals,
+                                                   params, sol, Q, c, A, l, u),
+      lambda s: (state.error, s), operand=(state.status))
+
+    state = OSQPState(iter_num=state.iter_num+1,
+                      error=error,
+                      status=status,
+                      primal_residuals=primal_residuals,
+                      dual_residuals=dual_residuals,
+                      rho_bar=rho_bar,
+                      eq_qp_last_sol=eq_qp_last_sol,
+                      params_precond=params_precond)
+    return base.OptStep(params=sol, state=state)
+
+  def run(self, init_params, params_obj, params_eq, params_ineq) -> base.OptStep:
+    """Return primal/dual variables.
+    
+    Args:
+      init_params: initial KKTSolution (can be None).
+      params_obj: pair (params_Q, c).
+      params_eq: params_A.
+      params_ineq: pair (l, u).
+    """
+    if init_params is None:
+      init_params = self.init_params(None, params_obj, params_eq, params_ineq)
+    
+    return super().run(init_params, params_obj, params_eq, params_ineq)
+
+  def l2_optimality_error(
+      self,
+      params: base.KKTSolution,
+      params_obj: Tuple[Any, Any],
+      params_eq: Any,
+      params_ineq: Tuple[Any, Any]) -> base.OptStep:
+    """Computes the L2 norm of the KKT residuals."""
+    pytree = self.optimality_fun(params, params_obj, params_eq, params_ineq)
+    return tree_l2_norm(pytree)
+
+  def __post_init__(self):
+    if self.eq_qp_preconditioner is None:
+      self._eq_qp_preconditioner_impl = NoPreconditioner()
+    elif self.eq_qp_preconditioner == 'jacobi':
+      if self.matvec_Q is not None or self.matvec_A is not None:
+        raise ValueError("'jacobi' preconditioner is only available for pytree of matrices (no support for matvec).")
+      self._eq_qp_preconditioner_impl = JacobiPreconditioner()
+    else:
+      raise ValueError(f"Invalid argument eq_qp_preconditioner={self.eq_qp_preconditioner}, expected None or 'jacobi'.")
+
+    self.matvec_Q = _make_linear_operator(self.matvec_Q)
+    self.matvec_A = _make_linear_operator(self.matvec_A)
+    
+    if self.check_primal_dual_infeasability == "auto":
+      jit, _ = self._get_loop_options()
+      self.check_primal_dual_infeasability = not jit
+
+    self.optimality_fun = _make_osqp_optimality_fun(self.matvec_Q, self.matvec_A)

--- a/jaxopt/_src/quadratic_prog.py
+++ b/jaxopt/_src/quadratic_prog.py
@@ -108,7 +108,7 @@ def _solve_constrained_qp_cvxpy(params_obj, params_eq, params_ineq):
   objective = 0.5 * cp.quad_form(x, Q) + c.T @ x
   constraints = [A @ x == b, G @ x <= h]
   pb = cp.Problem(cp.Minimize(objective), constraints)
-  pb.solve()
+  pb.solve(solver='OSQP')
 
   if pb.status in ["infeasible", "unbounded"]:
     raise ValueError("The problem is %s." % pb.status)

--- a/tests/osqp_test.py
+++ b/tests/osqp_test.py
@@ -1,0 +1,511 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+from jax.test_util import check_grads
+import numpy as onp
+
+from sklearn import datasets
+from sklearn import preprocessing
+from sklearn import svm
+
+from jaxopt import projection
+from jaxopt._src.base import KKTSolution
+from jaxopt._src.osqp import OSQP
+from jaxopt import QuadraticProgramming
+
+
+def get_random_osqp_problem(problem_size, eq_constraints, ineq_constraints):
+  assert problem_size >= eq_constraints  # very likely to be infeasible
+  onp.random.seed(problem_size + eq_constraints + ineq_constraints)
+  Q = onp.random.randn(problem_size, problem_size)
+  Q = Q.T.dot(Q)  # PSD matrix
+  c = onp.random.randn(problem_size)
+  A = onp.random.randn(ineq_constraints + eq_constraints, problem_size)
+  l = onp.random.randn(ineq_constraints)
+  u = l + jnp.abs(onp.random.randn(ineq_constraints))  # l < u
+  b = onp.random.randn(eq_constraints)  # Ax = b
+  l = jnp.concatenate([l, b])
+  u = jnp.concatenate([u, b])
+  return (Q, c), A, (l, u)
+
+
+def _from_osqp_form_to_default_form(Q, c, A, l, u):
+  """Return form used by QuadraticProgramming from OSQP form (support only matrices)."""
+  is_eq = l == u
+  is_ineq_l = jnp.logical_and(l != u, l != -jnp.inf)
+  is_ineq_u = jnp.logical_and(l != u, u != jnp.inf)
+  if jnp.any(is_eq):
+    A_eq, b = A[is_eq,:], l[is_eq]
+  else:
+    A_eq, b = jnp.zeros((1,len(c))), jnp.zeros((1,))
+  if jnp.any(is_ineq_l) and jnp.any(is_ineq_u):
+    G = jnp.concatenate([-A[is_ineq_l,:],A[is_ineq_u,:]])
+    h = jnp.concatenate([-l[is_ineq_l],u[is_ineq_u]])
+  elif jnp.any(is_ineq_l):
+    G, h = -A[is_ineq_l,:], -l[is_ineq_l]
+  elif jnp.any(is_ineq_u):
+    G, h = A[is_ineq_u,:], u[is_ineq_u]
+  else:
+    return (Q, c), (A_eq, b), None
+  return (Q, c), (A_eq, b), (G, h)
+
+
+class OSQPTest(jtu.JaxTestCase):
+
+  @parameterized.product(eq_ineq=[(0, 4), (4, 0), (4, 4)])
+  def test_small_qp(self, eq_ineq):
+    # Setup a random QP min_x 0.5*x'*Q*x + q'*x s.t. Ax = z; l <= z <= u;
+    eq_constraints, ineq_constraints = eq_ineq
+    onp.random.seed(42)
+    problem_size = 16
+    params_obj, params_eq, params_ineq = get_random_osqp_problem(problem_size, eq_constraints, ineq_constraints)
+    tol = 1e-5
+    osqp = OSQP(tol=tol)
+    params, state = osqp.run(None, params_obj, params_eq, params_ineq)
+    self.assertLessEqual(state.error, tol)
+    opt_error = osqp.l2_optimality_error(params, params_obj, params_eq, params_ineq)
+    self.assertAllClose(opt_error, 0.0, atol=1e-4)
+
+    def test_against_cvxpy(params_obj):
+      (Q, c), Ab, Gh = _from_osqp_form_to_default_form(params_obj[0], params_obj[1],
+                                                       params_eq, params_ineq[0], params_ineq[1])
+      Q = 0.5 * (Q + Q.T)
+      qp = QuadraticProgramming()
+      hyperparams = dict(params_obj=(Q, c), params_eq=Ab, params_ineq=Gh)
+      sol = qp.run(**hyperparams).params
+      return sol.primal
+
+    atol = 1e-4
+    cvx_primal = test_against_cvxpy(params_obj)
+    self.assertArraysAllClose(params.primal[0], cvx_primal, atol=atol)
+
+    def osqp_run(params_obj):
+      Q, c = params_obj
+      P = 0.5 * (Q + Q.T)
+      sol = osqp.run(None, (Q, c), params_eq, params_ineq).params
+      return sol.primal[0]
+
+    jacosqp = jax.jacrev(osqp_run)(params_obj)
+    jaccvxpy = jax.jacrev(test_against_cvxpy)(params_obj)
+    self.assertArraysAllClose(jacosqp[0], jaccvxpy[0], atol=5e-2)
+    self.assertArraysAllClose(jacosqp[1], jaccvxpy[1], atol=5e-2)
+
+  @parameterized.product(derivative_with_respect_to=["none", "obj", "eq", "ineq"])
+  def test_qp_eq_and_ineq(self, derivative_with_respect_to):
+    Q = 2 * jnp.array([[2.0, 0.5], [0.5, 1]])
+    c = jnp.array([1.0, 1.0])
+    A_eq = jnp.array([[1.0, 1.0]])
+    b = jnp.array([1.0])
+    G = jnp.array([[-1.0, 0.0], [0.0, -1.0]])
+    h = jnp.array([0.0, 0.0])
+    tol = 1e-5
+    osqp = OSQP(tol=tol, verbose=0)
+
+    @jax.jit
+    def osqp_run(Q, c, A_eq, G, b, h):
+      l = jnp.concatenate([b, jnp.full(h.shape, -jnp.inf)])
+      u = jnp.concatenate([b, jnp.full(h.shape, h)])
+      Q = 0.5 * (Q + Q.T) # we need to ensure that P is symmetric even after directional perturbations
+      A = jnp.concatenate([A_eq, G], axis=0)
+      return osqp.run(None, (Q, c), A, (l, u))
+
+    atol = 1e-2
+    eps = 1e-4
+
+    if "none" == derivative_with_respect_to:
+      params, state = osqp_run(Q, c, A_eq, G, b, h)
+      self.assertLessEqual(state.error, tol)
+      assert state.status == OSQP.SOLVED
+
+      qp = QuadraticProgramming()
+      hyperparams_qp = dict(params_obj=(Q, c), params_eq=(A_eq, b), params_ineq=(G, h))
+      params_qp, state = qp.run(**hyperparams_qp)
+      self.assertArraysAllClose(params.primal[0], params_qp.primal, atol=atol)
+
+    def keep_ineq_only(params):
+      b_idx = int(b.shape[0])
+      mu, phi = params.dual_ineq
+      return KKTSolution(params.primal, params.dual_eq, (mu[b_idx:], phi[b_idx:]))
+
+    if "obj" == derivative_with_respect_to:
+      solve_run_c = lambda c: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_c, args=(c,), order=1, modes=['rev'], eps=eps, atol=atol)
+      solve_run_Q = lambda Q: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_Q, args=(Q,), order=1, modes=['rev'], eps=eps, atol=atol)
+
+    if "eq" == derivative_with_respect_to:
+      solve_run_A_eq = lambda A_eq: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_A_eq, args=(A_eq,), order=1, modes=['rev'], eps=eps, atol=atol)
+      solve_run_b = lambda b: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_b, args=(b,), order=1, modes=['rev'], eps=eps, atol=atol)
+
+    if "ineq" == derivative_with_respect_to:
+      solve_run_G = lambda G: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_G, args=(G,), order=1, modes=['rev'], eps=eps, atol=atol)
+      solve_run_h = lambda h: keep_ineq_only(osqp_run(Q, c, A_eq, G, b, h).params)
+      check_grads(solve_run_h, args=(h,), order=1, modes=['rev'], eps=eps, atol=atol)
+
+  def test_projection_hyperplane(self):
+    x = jnp.array([1.0, 2.0])
+    a = jnp.array([-0.5, 1.5])
+    b = 0.3
+    q = -x
+    # Find ||y-x||^2 such that jnp.dot(y, a) = b.
+
+    matvec_Q = lambda params_Q,u: u
+    matvec_A = lambda params_A,u: jnp.dot(a, u).reshape(1)
+
+    tol = 1e-4
+    osqp = OSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, tol=tol, verbose=0)
+    sol, state = osqp.run(None, (None, q), None, (b, b))
+
+    assert state.status == OSQP.SOLVED
+    self.assertLessEqual(state.error, tol)
+    atol = 1e-3
+    opt_error = osqp.l2_optimality_error(sol, (None, q), None, (b, b))
+    self.assertAllClose(opt_error, 0.0, atol=atol)
+    expected = projection.projection_hyperplane(x, (a, b))
+    self.assertArraysAllClose(sol.primal[0], expected, atol=atol)
+
+  def test_projection_simplex(self):
+    @jax.jit
+    def _projection_simplex_qp(x, s=1.0):
+      Q = jnp.eye(len(x))
+      A_eq = jnp.array([jnp.ones_like(x)])
+      b = jnp.array([s])
+      G = -jnp.eye(len(x))
+      h = jnp.zeros_like(x)
+      A = jnp.concatenate([A_eq, G])
+      l = jnp.concatenate([b, jnp.full(h.shape, -jnp.inf)])
+      u = jnp.concatenate([b, h])
+      hyperparams = dict(params_obj=(Q, -x), params_eq=A,
+                         params_ineq=(l, u))
+
+      osqp = OSQP(tol=1e-5)
+      return osqp.run(None, **hyperparams).params.primal[0]
+
+    atol = 1e-3
+
+    rng = onp.random.RandomState(0)
+    x = jnp.array(rng.randn(10))
+    p = projection.projection_simplex(x)
+    p2 = _projection_simplex_qp(x)
+    self.assertArraysAllClose(p, p2, atol=atol)
+
+    J = jax.jacrev(projection.projection_simplex)(x)
+    J2 = jax.jacrev(_projection_simplex_qp)(x)
+    self.assertArraysAllClose(J, J2, atol=atol)
+
+  def test_eq_constrained_qp_with_pytrees(self):
+    rng = onp.random.RandomState(0)
+    Q = rng.randn(7, 7)
+    Q = onp.dot(Q, Q.T)
+    A = rng.randn(4, 7)
+
+    tmp = rng.randn(7)
+    # Must have the same pytree structure as the output of matvec_P.
+    c = {'foo':tmp[:3], 'bar':tmp[3:]}
+    # Must have the same pytree structure as the output of matvec_A.
+    b = [[rng.randn(1)] for _ in range(4)]
+
+    def matvec_Q(Q, dic):
+      x_ = jnp.concatenate([dic['foo'], dic['bar']])
+      res = jnp.dot(Q, x_)
+      return {'foo':res[:3], 'bar':res[3:]}
+
+    def matvec_A(A, dic):
+      x_ = jnp.concatenate([dic['foo'], dic['bar']])
+      z = jnp.dot(A, x_)
+      ineqs = jnp.split(z,z.shape[0])
+      return [[ineq] for ineq in ineqs]
+
+    tol = 1e-5
+    atol = 1e-4
+
+    # With pytrees directly.
+    hyperparams = dict(params_obj=(Q, c), params_eq=A, params_ineq=(b, b))
+    osqp = OSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, tol=tol)
+    # sol.primal has the same pytree structure as the output of matvec_Q.
+    # sol.dual_eq has the same pytree structure as the output of matvec_A.
+    sol_pytree, state = osqp.run(None, **hyperparams)
+    assert state.status == OSQP.SOLVED
+    self.assertAllClose(osqp.l2_optimality_error(sol_pytree, **hyperparams), 0.0, atol=atol)
+
+    flat_x = lambda x: jnp.concatenate([x['foo'], x['bar']])
+    flat_z = lambda z: jnp.concatenate([zi[0] for zi in z])
+
+    # With flattened pytrees.
+    c_flat = flat_x(c)
+    b_flat = flat_z(b)
+    hyperparams = dict(params_obj=(Q, c_flat), params_eq=A, params_ineq=(b_flat, b_flat))
+    osqp = OSQP(tol=tol)
+    sol = osqp.run(None, **hyperparams).params
+    self.assertAllClose(osqp.l2_optimality_error(sol, **hyperparams), 0.0, atol=atol)
+
+    # Check that the solutions match.
+    self.assertArraysAllClose(flat_x(sol_pytree.primal[0]), sol.primal[0], atol=atol)
+    self.assertArraysAllClose(flat_z(sol_pytree.primal[1]), sol.primal[1], atol=atol)
+    self.assertArraysAllClose(flat_z(sol_pytree.dual_eq), sol.dual_eq, atol=atol)
+
+  @parameterized.product(kernel=['linear','rbf'])
+  def test_binary_kernel_svm(self, kernel):
+    n_samples, n_features = 50, 8
+    n_informative = (3*n_features) // 4
+    # Prepare data.
+    X, y = datasets.make_classification(n_samples=n_samples, n_features=n_features,
+                                        n_informative=n_informative, n_classes=2,
+                                        random_state=0)
+    X = preprocessing.Normalizer().fit_transform(X)
+    y = y * 2 - 1.  # Transform labels from {0, 1} to {-1, 1}.
+    lam = 10.0
+    C = 1./ lam
+
+    if kernel == 'linear':
+      K = jnp.dot(X, X.T)
+    elif kernel == 'rbf':
+      dists = jnp.expand_dims(X, 0) - jnp.expand_dims(X, 1)
+      gamma = 1. / (X.shape[1] * jnp.var(X))  # like sklearn "scale" behavior
+      K = jnp.exp(-gamma * jnp.sum(dists**2, axis=[-1]))
+
+    # The dual objective is:
+    # fun(beta) = 0.5 beta^T K beta - beta^T y
+    # subject to
+    # sum(beta) = 0
+    # 0 <= beta_i <= C if y_i = 1
+    # -C <= beta_i <= 0 if y_i = -1
+    # where C = 1.0 / lam
+    matvec_A = lambda _,b: (b, jnp.sum(b))
+    l = -jax.nn.relu(-y * C), 0.
+    u =  jax.nn.relu( y * C), 0.
+    hyper_params = dict(params_obj=(K, -y), params_eq=None, params_ineq=(l, u))
+    tol = 1e-5
+    osqp = OSQP(matvec_A=matvec_A, tol=tol)
+
+    sol, state = osqp.run(None, **hyper_params)
+    self.assertLessEqual(state.error, tol)
+    atol = 1e-3
+    opt_error = osqp.l2_optimality_error(sol, **hyper_params)
+    self.assertAllClose(opt_error, 0.0, atol=atol)
+
+    def binary_kernel_svm_skl(K, y):
+      svc = svm.SVC(kernel="precomputed", C=C, tol=tol).fit(K, y)
+      dual_coef = onp.zeros(K.shape[0])
+      dual_coef[svc.support_] = svc.dual_coef_[0]
+      return dual_coef
+
+    beta_fit_skl = binary_kernel_svm_skl(K, y)
+    # we solve the dual problem with OSQP so the dual of svm.SVC
+    # corresponds to the primal variables of OSQP solution.
+    self.assertAllClose(sol.primal[0], beta_fit_skl, atol=1e-2)
+
+  def test_infeasible_polyhedron(self):
+    # argmin_p \|p - x\|_2 = argmin_p <p,Ip> - 2<x,p> = argmin_p 0.5pIp - <x,p>
+    # under p1 + p2 =  1
+    #            p2 =  1
+    #      -p1 + p2 = -1
+    #      -p1     <=  0
+    #      -p2     <=  0
+    # This QP is primal/dual infeasible.
+    A = jnp.array([[1.0, 1.0],[0.0, 1.0],[-1.0, 1.0]])
+    b = jnp.array([1.0, 1.0, -1.0])
+    G = jnp.array([[-1.0, 0.0], [0.0, -1.0]])
+    h = jnp.array([0.0, 0.0])
+
+    l = b, jnp.full(h.shape, -jnp.inf)
+    u = b, h
+
+    def matvec_A(_, p):
+      return jnp.dot(A, p), jnp.dot(G, p)
+
+    x = jnp.zeros(2)
+    I = jnp.eye(len(x))
+    hyper_params = dict(params_obj=(I, -x), params_eq=None, params_ineq=(l, u))
+    osqp = OSQP(matvec_A=matvec_A, check_primal_dual_infeasability=True, tol=1e-5)
+    sol, state = osqp.run(None, **hyper_params)
+    assert state.status in [OSQP.PRIMAL_INFEASIBLE, OSQP.DUAL_INFEASIBLE]
+
+  def test_infeasible_primal_only(self):
+    # argmin   x1 + x2
+    # under    x1 >= 6
+    #          x2 >= 6
+    #     x1 + x2 <= 11
+    # This QP is primal infeasible.
+    Q = jnp.zeros((2,2))
+    c = jnp.array([1.,1.])
+
+    def matvec_A(_, x):
+      return x[0], x[1], x[0] + x[1]
+    l = 6., 6., -jnp.inf
+    u = jnp.inf, jnp.inf, 11.
+    
+    hyper_params = dict(params_obj=(Q, c), params_eq=None, params_ineq=(l, u))
+    osqp = OSQP(matvec_A=matvec_A, check_primal_dual_infeasability=True)
+    sol, state = osqp.run(None, **hyper_params)
+    assert state.status == OSQP.PRIMAL_INFEASIBLE
+
+  def test_unbounded_primal(self):
+    # argmin   x1 -2x2 + x3
+    # under  x1 + x2 >= 0
+    #              x3 = 1
+    # This (degenerated) QP is dual infeasible (unbounded primal).
+    def matvec_A(_, x):
+      return x[0] + x[1], x[2]
+    l = 0., 1.
+    u = jnp.inf, 1.
+
+    def matvec_Q(_,x):
+      return 0., 0., 0.
+
+    hyper_params = dict(params_obj=(None, (-1., -2., 1.)), params_eq=None, params_ineq=(l, u))
+    osqp = OSQP(matvec_Q=matvec_Q, matvec_A=matvec_A,
+                check_primal_dual_infeasability=True,
+                tol=1e-3)
+    init_params = osqp.init_params(init_x=(5., -3., 0.02), **hyper_params)
+    sol, state = osqp.run(init_params, **hyper_params)
+    assert state.status == OSQP.DUAL_INFEASIBLE
+
+  def test_jacobi_preconditioner(self):
+    # Portfolio optimization
+    # Problems of the form
+    #     max_x mu^Tx - gamma x Cov x
+    #     under sum_i x_i  = 1
+    #                 x_i >= 0
+    # with Cov = F@F.T + D the risk model, F @ F.T low rank, and D diagonal
+    # mu the expected return
+    onp.random.seed(0)
+    assets, factors = 10, 3
+    gamma = 1
+    F = onp.random.randn(assets, factors) 
+    D = jnp.diag(onp.random.uniform(0., factors ** 0.5, assets))
+    Cov = 2*gamma*(F @ F.T + D)   # minimize risk
+    mu = onp.random.randn(assets)   # maximize gain
+
+    A = jnp.concatenate([jnp.ones((1, assets)), jnp.eye(assets)], axis=0)
+    l = jnp.concatenate([jnp.array([1.]), jnp.zeros(assets)])
+    u = jnp.concatenate([jnp.array([1.]), jnp.full(assets, jnp.inf)])
+
+    tol = 1e-5
+    atol = 1e-3
+
+    hyper_params = dict(params_obj=(Cov, mu), params_eq=A, params_ineq=(l, u))
+    osqp = OSQP(tol=tol, eq_qp_preconditioner='jacobi')
+    sol, state = osqp.run(None, **hyper_params)
+    self.assertLessEqual(state.error, tol)
+    assert state.status == OSQP.SOLVED
+    opt_error = osqp.l2_optimality_error(sol, **hyper_params)
+    self.assertAllClose(opt_error, 0.0, atol=atol)
+
+    # Default preconditioner: Identity
+    # Jacobi preconditioner J should be better.
+    # We can check this heuristically with:
+    #    || M@P@x - x ||_2 where preconditioner P approximates M^{-1}
+    # Error for Default preconditioner:    M@x   - x
+    # Error for Jacobi preconditioner:     M@J@x - x
+    # The error of Jacobi is expected to be lower.
+    sigma = 1e-6
+    J = osqp._eq_qp_preconditioner_impl
+    x = sol.primal[0]
+    for rho_bar in [1e-4, 0.001, 0.01, 0.1, 1., 10., 100., 1000, 1e4]:
+      params_precond = J.init_params_precond(Cov, A, sigma, rho_bar)
+      M = Cov + sigma * jnp.eye(assets) + rho_bar * A.T @ A
+      approx_x = M @ J(params_precond, x)
+      diff = jnp.sum((approx_x - x)**2)**0.5
+      no_precond_approx = M @ x
+      no_precond_diff = jnp.sum((no_precond_approx - x)**2)**0.5
+      self.assertLessEqual(diff, no_precond_diff)
+
+  def test_lasso(self):
+    # Objective:
+    #     min ||data @ x - targets||_2^2 + 2 * n * lam ||x||_1
+    #
+    # Converted in QP:
+    #
+    #     min y^Ty + 2*n*lam 1^T t
+    #     under y = data @ x - targets
+    #          -t <= x <= t
+    #
+    # With OSQP formulation:
+    #
+    #     min y^Ty + 2*n*lam 1^T t
+    #     under       targets = data @ x - y
+    #           0         <= x + t <= infinity
+    #           -infinity <= x - t <= 0
+    #
+    # Note that we use 2n corrective factor in objective to
+    # optimize same objective as ProximalGradient.
+    n = 10
+    data, targets = datasets.make_regression(n_samples=n, n_features=3, random_state=0)
+    lam = 10.0
+
+    def matvec_Q(_, xyt):
+      x, y, t = xyt
+      return jnp.zeros_like(x), 2 * y, jnp.zeros_like(t)
+    
+    c = jnp.zeros(data.shape[1]), jnp.zeros(data.shape[0]), 2*n*lam * jnp.ones(data.shape[1])
+
+    def matvec_A(data, xyt):
+      x, y, t = xyt
+      residuals = data @ x - y
+      return residuals, x + t, x - t
+
+    l = targets, jnp.zeros_like(c[0]), jnp.full(data.shape[1], -jnp.inf)
+    u = targets, jnp.full(data.shape[1], jnp.inf), jnp.zeros_like(c[0])
+
+    tol = 1e-4
+    atol = 1e-2
+
+    hyper_params = dict(params_obj=(None, c), params_eq=data, params_ineq=(l, u))
+    osqp = OSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, tol=tol)
+    sol, state = osqp.run(None, **hyper_params)
+    self.assertLessEqual(state.error, tol)
+    assert state.status == OSQP.SOLVED
+    opt_error = osqp.l2_optimality_error(sol, **hyper_params)
+    self.assertAllClose(opt_error, 0.0, atol=atol)
+
+    # Verify with Proximal Gradient
+
+    def run_osqp(data):
+      hyper_params = dict(params_obj=(None, c), params_eq=data, params_ineq=(l, u))
+      sol, state = osqp.run(None, **hyper_params)
+      return sol.primal[0][0]
+
+    from jaxopt import objective
+    from jaxopt import prox
+    from jaxopt import ProximalGradient
+
+    fun = objective.least_squares
+    w_init = jnp.zeros(data.shape[1])
+    pg = ProximalGradient(fun=fun, prox=prox.prox_lasso, maxiter=400, tol=tol,
+                          acceleration=True)
+    def run_prox(data):
+      w_fit, info = pg.run(w_init, hyperparams_prox=lam, data=(data, targets))
+      return w_fit
+
+    w_fit = run_prox(data)
+    self.assertArraysAllClose(sol.primal[0][0], w_fit, atol=atol)
+
+    jac_osqp = jax.jacrev(run_osqp)(data)
+    jac_prox = jax.jacrev(run_prox)(data)
+    self.assertArraysAllClose(jac_osqp, jac_prox, atol=1e-2)
+
+
+if __name__ == '__main__':
+  jax.config.update("jax_enable_x64", True)
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
First attempt to implement a general QP solver based on ADMM and heuristics of OSQP: https://arxiv.org/pdf/1711.08013.pdf

Solve problems of the form:

![CodeCogsEqn](https://user-images.githubusercontent.com/8568881/140507316-bd578b0c-f691-48aa-a5f4-f4695fa119b8.png)


### Supported features
- suppports `l=-jnp.inf`, `u=jnp.inf` and `l=u`.
- arbitrary pytrees for `q, x` and `l, u, z` (as long they are compatible with each other).
- arbitrary matvecs for P and A (their input/output need to be compatible with pytrees `x,z`). Those matvecs can be parametrized by `params_P,params_A`.
- primal/dual infeasability detection (can be turn on/off for speed concerns).
- primal/dual variables computation.
- implicit differentiation wrt P (or params_P), q, A (or params_A), l, u.
- objective does not need to be _stricly_ convex (convex is sufficient), and constraints do not need to be linearly independant. Can be used for Linear Programming as a result (not most effective algorithm for this purpose however).
- differents levels of verbosity for debugging.
- `jit/vmap` support (unlike CVPY).

### Implementation choices
- automatic tuning of learning rate `rho` at each step.
- indirect solving of linear system with conjugate gradient, re-using past-solution of previous step. In [OSQP original implementation](https://github.com/osqp/osqp) authors uses direct method with LDL factorization caching. It forces them to update `rho` less frequently. They take advantage of sparsity patterns in the system to factorize efficiently. Those heuristics might be inapropriate for `jit` when parallelism is available.
- same hyper-parameters as OSQP original implementation, but can be changed by user if required.

### Missing features:
- solution polishing (increases precision at the end by guessing active inequalities of optimum and solving the corresponding KKT system), to counterbalance linear convergence rate of ADMM (slow). We need to assess the relevance of this option in Deep learning context.
- pre-conditioning of objective/constraints using _Ruiz equilibration_ to improve condition number on P,A. Tricky to do efficiently with matvecs, but possible.
- non convex problems (i.e not PSD P) detection (tricky and not cheap, not guaranteed even by OSQP authors).
- interface compatible with `quadratic_programming.py` for uniformity.
- documentation, reference in `changelog`.

### Tests (in `float64` setting)
- tests on simple random QP against cvxpy.
- implicit differentiation tested with finite differences and QuadraticProgramming implicit differentiation.
- test of linear/rbf c-svm against sklearn.svm.SVC. 
- simple primal/dual infeasible QP.
- other tests identical to `quadratic_programming_tests.py`.

### Missing tests
- tests on TPU / GPU.
- tests with `float32` precision.
- tests on (very) big instances.
- benchmarks against CVXPY for precision/speed.
- tests on almost infeasible QP (small feasible set).
- tests on LP problems (i.e when P = 0).
- evaluate errors on VJP when the computation is early stopped with low accuracy.

The solver is very fast to reach low accuracy feasible solution (often less than a dozen iterations), takes more time to reach medium accuracy (required for satisfying `l2_optimality_error` in implicit differentiation), and often fail to each high accuracy solution due to various numerical issues (errors in linear system). Solution polishing and pre-conditioning may be implemented to solve those issues. Playing with `tol,sigma,eq_qp_solve_tol` can improve accuracy.

The code is very verbose due to pytree support. To facilitate debuging, I made the choice to stick closely to OSQP pseudo-code, and add various comments.

This PR is open mainly for discussion, and make this "alpha" available for tests ( @GeoffNN ). There is a lot to be discussed, Some magical constants found by OSQP authors were chosen because it was effective on their `float64` architecture and pipeline. We might need to found new magical constants for our particular setting (GPU).