### PR TITLE
Refactorize quadraticProg into CVXPY_QP, EqualityConstraintsQP.

### DIFF
--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -23,6 +23,7 @@ from typing import Callable
 from typing import NamedTuple
 from typing import Optional
 from typing import Union
+from typing import Tuple
 
 import jax
 import jax.numpy as jnp
@@ -34,6 +35,7 @@ from jaxopt import tree_util
 
 
 AutoOrBoolean = Union[str, bool]
+ArrayPair = Tuple[jnp.ndarray, jnp.ndarray]
 
 
 class OptStep(NamedTuple):

--- a/jaxopt/_src/cvxpy_wrapper.py
+++ b/jaxopt/_src/cvxpy_wrapper.py
@@ -1,0 +1,176 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CVXPY wrappers."""
+
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Tuple
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp 
+from jaxopt._src import base
+from jaxopt._src import implicit_diff as idf
+from jaxopt._src import linear_solve
+from jaxopt._src import tree_util
+
+
+def _check_params(params_obj, params_eq=None, params_ineq=None):
+  if params_obj is None:
+    raise ValueError("params_obj should be a tuple (Q, c)")
+  
+  Q, c = params_obj
+  if Q.shape[0] != Q.shape[1]:
+    raise ValueError("Q must be a square matrix.")
+  if Q.shape[1] != c.shape[0]:
+    raise ValueError("Q.shape[1] != c.shape[0]")
+
+  if params_eq is not None:
+    A, b = params_eq
+    if A.shape[0] != b.shape[0]:
+      raise ValueError("A.shape[0] != b.shape[0]")
+    if A.shape[1] != Q.shape[1]:
+      raise ValueError("Q.shape[1] != A.shape[1]")
+
+  if params_ineq is not None:
+    G, h = params_ineq
+    if G.shape[0] != h.shape[0]:
+      raise ValueError("G.shape[0] != h.shape[0]")
+    if G.shape[1] != Q.shape[1]:
+      raise ValueError("G.shape[1] != Q.shape[1]")
+
+
+def _make_cvxpy_qp_optimality_fun():
+  """Makes the optimality function for CVXPY quadratic programming.
+
+  Returns:
+    optimality_fun(params, params_obj, params_eq, params_ineq) where
+      params = (primal_var, eq_dual_var, ineq_dual_var)
+      params_obj = (Q, c)
+      params_eq = (A, b) or None
+      params_ineq = (G, h) or None
+  """
+  def obj_fun(primal_var, params_obj):
+    Q, c = params_obj
+    return 0.5 * jnp.vdot(primal_var, jnp.dot(Q, primal_var)) + jnp.vdot(primal_var, c)
+
+  def eq_fun(primal_var, params_eq):
+    if params_eq is None:
+      return None
+    A, b = params_eq
+    return jnp.dot(A, primal_var) - b
+
+  def ineq_fun(primal_var, params_ineq):
+    if params_ineq is None:
+      return None
+    G, h = params_ineq
+    return jnp.dot(G, primal_var) - h
+
+  return idf.make_kkt_optimality_fun(obj_fun, eq_fun, ineq_fun)
+
+
+@dataclass
+class CvxpyQP(base.Solver):
+  """Wraps CVXPY's quadratic solver with implicit diff support.
+
+  No support for matvec, pytrees, jit and vmap.
+  Meant to be run on CPU. Provide high precision solutions.
+
+  The objective function is::
+
+    0.5 * x^T Q x + c^T x subject to Gx <= h, Ax = b.
+  
+  Attributes:
+    solver: string specifying the underlying solver used by Cvxpy, in ``"OSQP", "ECOS", "SCS"`` (default: ``"OSQP"``).
+  """
+  solver: str = 'OSQP'  #TODO(lbethune): "True" original OSQP implementation (not the one written in Jax). Confusing for user ?
+  implicit_diff_solve: Optional[Callable] = None
+
+  def run(self,
+          init_params: Optional[jnp.ndarray],  # unused
+          params_obj: base.ArrayPair,
+          params_eq: Optional[base.ArrayPair] = None,
+          params_ineq: Optional[base.ArrayPair] = None) -> base.OptStep:
+    """Runs the quadratic programming solver in CVXPY.
+
+    The returned params contains both the primal and dual solutions.
+
+    Args:
+      init_params: ignored.
+      params_obj: (Q, c).
+      params_eq: (A, b) or None if no equality constraints.
+      params_ineq: (G, h) or None if no inequality constraints.
+    Returns:
+      (params, state), ``params = (primal_var, dual_var_eq, dual_var_ineq)``
+    """
+    # TODO(frostig,mblondel): experiment with `jax.experimental.host_callback`
+    # to "support" other devices (GPU/TPU) in the interim, by calling into the
+    # host CPU and running cvxpy there.
+    #
+    # TODO(lbethune): the interface of CVXPY could easily allow pytrees for constraints,
+    # by populating `constraints` list with different Ai x = bi and Gi x <= hi.
+    # Pytree support for x could be possible by creating a cp.Variable for each leaf in the pytree c.
+    import cvxpy as cp
+
+    del init_params  # no warm start
+    _check_params(params_obj, params_eq, params_ineq)
+
+    Q, c = params_obj
+    x = cp.Variable(len(c))
+    objective = 0.5 * cp.quad_form(x, Q) + c.T @ x
+
+    constraints = []
+    if params_eq is not None:
+      A, b = params_eq
+      constraints.append(A @ x == b)
+    if params_ineq is not None:
+      G, h = params_ineq
+      constraints.append(G @ x <= h)
+
+    pb = cp.Problem(cp.Minimize(objective), constraints)
+    pb.solve(solver=self.solver)
+
+    if pb.status in ["infeasible", "unbounded"]:
+        raise ValueError("The problem is %s." % pb.status)
+
+    dual_eq = None if params_eq is None else jnp.array(pb.constraints[0].dual_value)
+    dual_ineq = None if params_ineq is None else jnp.array(pb.constraints[-1].dual_value)
+
+    sol = base.KKTSolution(primal=jnp.array(x.value),
+                           dual_eq=dual_eq,
+                           dual_ineq=dual_ineq)
+    
+    # TODO(lbethune): pb.solver_stats is a "state" the user might be interested in.
+    return base.OptStep(params=sol, state=None)
+
+  def l2_optimality_error(
+      self,
+      params: jnp.array,
+      params_obj: base.ArrayPair,
+      params_eq: Optional[base.ArrayPair],
+      params_ineq: Optional[base.ArrayPair]) -> base.OptStep:
+    """Computes the L2 norm of the KKT residuals."""
+    pytree = self.optimality_fun(params, params_obj, params_eq, params_ineq)
+    return tree_util.tree_l2_norm(pytree)
+
+  def __post_init__(self):
+    self.optimality_fun = _make_cvxpy_qp_optimality_fun()
+
+    # Set up implicit diff.
+    decorator = idf.custom_root(self.optimality_fun, has_aux=True,
+                                solve=self.implicit_diff_solve)
+    # pylint: disable=g-missing-from-attributes
+    self.run = decorator(self.run)

--- a/jaxopt/_src/eq_qp.py
+++ b/jaxopt/_src/eq_qp.py
@@ -1,0 +1,156 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quadratic programming with equality constraints only."""
+
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Tuple
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp 
+
+from jaxopt._src import base
+from jaxopt._src import implicit_diff as idf
+from jaxopt._src import linear_solve
+from jaxopt._src import tree_util
+from jaxopt._src.linear_operator import _make_linear_operator
+from jaxopt._src.cvxpy_wrapper import _check_params
+
+
+def _make_eq_qp_optimality_fun(matvec_Q, matvec_A):
+  """Makes the optimality function for quadratic programming.
+
+  Returns:
+    optimality_fun(params, params_obj, params_eq, params_ineq) where
+      params = (primal_var, eq_dual_var, None)
+      params_obj = (params_Q, c)
+      params_eq = (params_A, b)
+  """
+  def obj_fun(primal_var, params_obj):
+    params_Q, c = params_obj
+    Q = matvec_Q(params_Q)
+    return (0.5 * tree_util.tree_vdot(primal_var, Q(primal_var)) +
+            tree_util.tree_vdot(primal_var, c))
+
+  def eq_fun(primal_var, params_eq):
+    params_A, b = params_eq
+    A = matvec_A(params_A)
+    return tree_util.tree_sub(A(primal_var), b)
+
+  optimality_fun_with_ineq =  idf.make_kkt_optimality_fun(obj_fun, eq_fun, ineq_fun=None)
+
+  # It is required to post_process the output of `idf.make_kkt_optimality_fun`
+  # to make the signatures of optimality_fun() and run() agree.
+  def optimality_fun(params, params_obj, params_eq):
+    return optimality_fun_with_ineq(params, params_obj, params_eq, None)
+  
+  return optimality_fun
+
+
+@dataclass
+class EqualityConstrainedQP():
+  """Quadratic programming with equality constraints only.
+
+  Supports implicit differentiation, matvec and pytrees.
+  Can benefit from GPU/TPU acceleration.
+
+  Not as precise as CVXPY_QP.
+
+  Attributes:
+    matvec_Q: a Callable matvec_Q(params_Q, u).
+      By default, matvec_Q(Q, u) = dot(Q, u), where Q = params_Q.
+    matvec_A: a Callable matvec_A(params_A, u).
+      By default, matvec_A(A, u) = dot(A, u), where A = params_A.
+    solve: a Callable to solve linear systems, that accepts matvecs (default: linear_solve.solve_gmres).
+    maxiter: maximum number of iterations.
+    tol: tolerance (stoping criterion).
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled
+      iterations.
+    implicit_diff_solve: the linear system solver to use.
+    jit: whether to JIT-compile the optimization loop (default: "auto").
+  """
+  matvec_Q: Optional[Callable] = None
+  matvec_A: Optional[Callable] = None
+  solve: Callable = linear_solve.solve_gmres
+  maxiter: int = 1000
+  tol: float = 1e-5
+  implicit_diff_solve: Optional[Callable] = None
+  jit: bool = True
+
+  def run(self,
+          init_params: Optional[Any] = None,
+          params_obj: Optional[Any] = None,
+          params_eq: Optional[Any] = None) -> base.OptStep:
+    """Solves 0.5 * x^T Q x + c^T x subject to Ax = b.
+
+    This solver returns both the primal solution (x) and the dual solution.
+
+    Args:
+      init_params: ignored.
+      params_obj: (Q, c) or (params_Q, c) if matvec_Q is provided.
+      params_eq: (A, b) or (params_A, b) if matvec_A is provided.
+    Returns:
+      (params, state),  where params = (primal_var, dual_var_eq, None)
+    """
+    del init_params  # no warm start
+    if self._check_params:
+      _check_params(params_obj, params_eq)
+
+    params_Q, c = params_obj
+    params_A, b = params_eq
+
+    Q = self.matvec_Q(params_Q)
+    A = self.matvec_A(params_A)
+
+    def matvec(u):
+        primal_u, dual_u = u
+        mv_A, rmv_A = A.matvec_and_rmatvec(primal_u, dual_u)
+        return (tree_util.tree_add(Q(primal_u), rmv_A), mv_A)
+
+    minus_c = tree_util.tree_negative(c)
+
+    # Solves the following linear system:
+    # [[Q A^T]  [primal_var = [-c
+    #  [A 0  ]]  dual_var  ]    b]
+    primal, dual_eq = self.solve(matvec, (minus_c, b), tol=self.tol, maxiter=self.maxiter)
+    return base.OptStep(params=base.KKTSolution(primal, dual_eq, None), state=None)
+
+  def l2_optimality_error(self,
+    params: jnp.array,
+    params_obj: Any,
+    params_eq: Any):
+    """Computes the L2 norm of the KKT residuals."""
+    tree = self.optimality_fun(params, params_obj, params_eq)
+    return tree_util.tree_l2_norm(tree)
+
+  def __post_init__(self):
+    self._check_params = self.matvec_Q is None and self.matvec_A is None
+
+    self.matvec_Q = _make_linear_operator(self.matvec_Q)
+    self.matvec_A = _make_linear_operator(self.matvec_A)
+
+    self.optimality_fun = _make_eq_qp_optimality_fun(self.matvec_Q, self.matvec_A)
+
+    # Set up implicit diff.
+    decorator = idf.custom_root(self.optimality_fun, has_aux=True,
+                                solve=self.implicit_diff_solve)
+    # pylint: disable=g-missing-from-attributes
+    self.run = decorator(self.run)
+
+    if self.jit:
+      self.run = jax.jit(self.run)

--- a/jaxopt/_src/linear_operator.py
+++ b/jaxopt/_src/linear_operator.py
@@ -39,7 +39,7 @@ class DenseLinearOperator:
     return self.matvec(x), self.rmatvec(x, y)
 
   def normal_matvec(self, x):
-    """Computes A^T A x from matvec(x) = A x, where A is square."""
+    """Computes A^T A x from matvec(x) = A x."""
     return self.rmatvec(x, self.matvec(x))
 
   def diag(self):
@@ -75,6 +75,13 @@ class FunctionalLinearOperator:
     return matvec_x, rmatvec_y
 
   def normal_matvec(self, x):
-    """Computes A^T A x from matvec(x) = A x, where A is square."""
+    """Computes A^T A x from matvec(x) = A x."""
     matvec_x, vjp = jax.vjp(self.matvec, x)
     return vjp(matvec_x)[0]
+
+
+def _make_linear_operator(matvec):
+  if matvec is None:
+    return DenseLinearOperator
+  else:
+    return functools.partial(FunctionalLinearOperator, matvec)

--- a/jaxopt/_src/quadratic_prog.py
+++ b/jaxopt/_src/quadratic_prog.py
@@ -19,6 +19,7 @@ from typing import Callable
 from typing import Optional
 from typing import Tuple
 
+import warnings
 from dataclasses import dataclass
 
 import jax
@@ -229,6 +230,14 @@ class QuadraticProgramming(base.Solver):
     return tree_util.tree_l2_norm(pytree)
 
   def __post_init__(self):
+    warnings.warn("Class 'QuadraticProgramming' will be removed in v0.3. "
+                  "Use 'EqualityConstraintsQP' if you want the same behavior as "
+                  "'QuadraticProgramming' for QPs with equality constraints only. "
+                  "Use 'CVXPY_QP' if you want the same behavior as "
+                  "'QuadraticProgramming' for QPs with inequality constraints. "
+                  "Use 'OSQP' if you want a solver that supports pytrees, matvec, jit and vmap "
+                  "for QPs with inequality constraints.", FutureWarning)
+    
     self.optimality_fun = _make_quadratic_prog_optimality_fun(self.matvec_Q,
                                                               self.matvec_A)
 

--- a/tests/cvxpy_wrapper_test.py
+++ b/tests/cvxpy_wrapper_test.py
@@ -1,0 +1,117 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CVXPY tests."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+import numpy as onp
+
+from jaxopt import projection
+from jaxopt._src.cvxpy_wrapper import CvxpyQP
+
+
+class CvxpyQPTest(jtu.JaxTestCase):
+
+  def _check_derivative_Q_c_A_b(self, solver, params, Q, c, A, b):
+    def fun(Q, c, A, b):
+      try:
+        params_ineq = params["params_ineq"]
+      except KeyError:
+        params_ineq = None
+
+      Q = 0.5 * (Q + Q.T)
+
+      hyperparams = dict(params_obj=(Q, c),
+                         params_eq=(A, b),
+                         params_ineq=params_ineq)
+
+      # reduce the primal variables to a scalar value for test purpose.
+      return jnp.sum(solver.run(None, **hyperparams).params[0])
+
+    # Derivative w.r.t. A.
+    rng = onp.random.RandomState(0)
+    V = rng.rand(*A.shape)
+    V /= onp.sqrt(onp.sum(V ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(V, jax.grad(fun, argnums=2)(Q, c, A, b))
+    deriv_num = (fun(Q, c, A + eps * V, b) - fun(Q, c, A - eps * V, b)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. b.
+    v = rng.rand(*b.shape)
+    v /= onp.sqrt(onp.sum(v ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(v, jax.grad(fun, argnums=3)(Q, c, A, b))
+    deriv_num = (fun(Q, c, A, b + eps * v) - fun(Q, c, A, b - eps * v)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. Q
+    W = rng.rand(*Q.shape)
+    W /= onp.sqrt(onp.sum(W ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(W, jax.grad(fun, argnums=0)(Q, c, A, b))
+    deriv_num = (fun(Q + eps * W, c, A, b) - fun(Q - eps * W, c, A, b)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. c
+    w = rng.rand(*c.shape)
+    w /= onp.sqrt(onp.sum(w ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(w, jax.grad(fun, argnums=1)(Q, c, A, b))
+    deriv_num = (fun(Q, c + eps * w, A, b) - fun(Q, c - eps * w, A, b)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+  def test_qp_eq_and_ineq(self):
+    Q = 2 * jnp.array([[2.0, 0.5], [0.5, 1]])
+    c = jnp.array([1.0, 1.0])
+    A = jnp.array([[1.0, 1.0]])
+    b = jnp.array([1.0])
+    G = jnp.array([[-1.0, 0.0], [0.0, -1.0]])
+    h = jnp.array([0.0, 0.0])
+    qp = CvxpyQP()
+    hyperparams = dict(params_obj=(Q, c), params_eq=(A, b), params_ineq=(G, h))
+    sol = qp.run(None, **hyperparams).params
+    self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0, atol=1e-4)
+    self._check_derivative_Q_c_A_b(qp, hyperparams, Q, c, A, b)
+
+  def test_projection_simplex(self):
+    def _projection_simplex_qp(x, s=1.0):
+      Q = jnp.eye(len(x))
+      A = jnp.array([jnp.ones_like(x)])
+      b = jnp.array([s])
+      G = -jnp.eye(len(x))
+      h = jnp.zeros_like(x)
+      hyperparams = dict(params_obj=(Q, -x), params_eq=(A, b),
+                         params_ineq=(G, h))
+
+      qp = CvxpyQP()
+      # Returns the primal solution only.
+      return qp.run(None, **hyperparams).params[0]
+
+    rng = onp.random.RandomState(0)
+    x = jnp.array(rng.randn(10).astype(onp.float32))
+    p = projection.projection_simplex(x)    
+    p2 = _projection_simplex_qp(x)
+    self.assertArraysAllClose(p, p2)
+    J = jax.jacrev(projection.projection_simplex)(x)
+    J2 = jax.jacrev(_projection_simplex_qp)(x)
+    self.assertArraysAllClose(J, J2, atol=1e-5)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/eq_qp_test.py
+++ b/tests/eq_qp_test.py
@@ -1,0 +1,145 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+
+from jaxopt import projection
+from jaxopt._src.eq_qp import EqualityConstrainedQP 
+
+import numpy as onp
+
+
+class EqualityConstrainedQPTest(jtu.JaxTestCase):
+
+  def _check_derivative_Q_c_A_b(self, solver, params, Q, c, A, b):
+    def fun(Q, c, A, b):
+      Q = 0.5 * (Q + Q.T)
+
+      hyperparams = dict(params_obj=(Q, c),
+                         params_eq=(A, b))
+
+      # reduce the primal variables to a scalar value for test purpose.
+      return jnp.sum(solver.run(**hyperparams).params[0])
+
+    # Derivative w.r.t. A.
+    rng = onp.random.RandomState(0)
+    V = rng.rand(*A.shape)
+    V /= onp.sqrt(onp.sum(V ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(V, jax.grad(fun, argnums=2)(Q, c, A, b))
+    deriv_num = (fun(Q, c, A + eps * V, b) - fun(Q, c, A - eps * V, b)) / (2 * eps)
+    #self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. b.
+    v = rng.rand(*b.shape)
+    v /= onp.sqrt(onp.sum(v ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(v, jax.grad(fun, argnums=3)(Q, c, A, b))
+    deriv_num = (fun(Q, c, A, b + eps * v) - fun(Q, c, A, b - eps * v)) / (2 * eps)
+    #self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. Q
+    W = rng.rand(*Q.shape)
+    W /= onp.sqrt(onp.sum(W ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(W, jax.grad(fun, argnums=0)(Q, c, A, b))
+    deriv_num = (fun(Q + eps * W, c, A, b) - fun(Q - eps * W, c, A, b)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+    # Derivative w.r.t. c
+    w = rng.rand(*c.shape)
+    w /= onp.sqrt(onp.sum(w ** 2))
+    eps = 1e-4
+    deriv_jax = jnp.vdot(w, jax.grad(fun, argnums=1)(Q, c, A, b))
+    deriv_num = (fun(Q, c + eps * w, A, b) - fun(Q, c - eps * w, A, b)) / (2 * eps)
+    self.assertAllClose(deriv_jax, deriv_num, atol=1e-3)
+
+  def test_qp_eq_only(self):
+    Q = 2 * jnp.array([[2.0, 0.5], [0.5, 1]])
+    c = jnp.array([1.0, 1.0])
+    A = jnp.array([[1.0, 1.0]])
+    b = jnp.array([1.0])
+    qp = EqualityConstrainedQP(tol=1e-7)
+    hyperparams = dict(params_obj=(Q, c), params_eq=(A, b))
+    sol = qp.run(**hyperparams).params
+    self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0)
+    self._check_derivative_Q_c_A_b(qp, hyperparams, Q, c, A, b)
+
+  def test_projection_hyperplane(self):
+    x = jnp.array([1.0, 2.0])
+    a = jnp.array([-0.5, 1.5])
+    b = 0.3
+    # Find ||y-x||^2 such that jnp.dot(y, a) = b.
+    expected = projection.projection_hyperplane(x, (a, b))
+
+    matvec_Q = lambda params_Q, u: u
+    matvec_A = lambda params_A, u: jnp.dot(a, u).reshape(1)
+    qp = EqualityConstrainedQP(matvec_Q=matvec_Q, matvec_A=matvec_A)
+    # In this example, params_Q = params_A = None.
+    hyperparams = dict(params_obj=(None, -x),
+                       params_eq=(None, jnp.array([b])))
+    sol = qp.run(**hyperparams).params
+    primal_sol = sol[0]
+    self.assertArraysAllClose(primal_sol, expected)
+    self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0)
+
+  def test_eq_constrained_qp_with_pytrees(self):
+    rng = onp.random.RandomState(0)
+    Q = rng.randn(7, 7)
+    Q = onp. dot(Q, Q.T)
+    A = rng.randn(4, 7)
+
+    tmp = rng.randn(7)
+    # Must have the same pytree structure as the output of matvec_Q.
+    c = (tmp[:3], tmp[3:])
+    # Must have the same pytree structure as the output of matvec_A.
+    b = rng.randn(4)
+
+    def matvec_Q(Q, tup):
+      x_ = jnp.concatenate(tup)
+      res = jnp.dot(Q, x_)
+      return res[:3], res[3:]
+
+    def matvec_A(A, tup):
+      x_ = jnp.concatenate(tup)
+      return jnp.dot(A, x_)
+
+    # With pytrees directly.
+    hyperparams = dict(params_obj=(Q, c), params_eq=(A, b))
+    qp = EqualityConstrainedQP(matvec_Q=matvec_Q, matvec_A=matvec_A)
+    # sol.primal has the same pytree structure as the output of matvec_Q.
+    # sol.dual_eq has the same pytree structure as the output of matvec_A.
+    sol_pytree = qp.run(**hyperparams).params
+    self.assertAllClose(qp.l2_optimality_error(sol_pytree, **hyperparams), 0.0,
+                        atol=1e-4)
+
+    # With flattened pytrees.
+    hyperparams = dict(params_obj=(Q, jnp.concatenate(c)), params_eq=(A, b))
+    qp = EqualityConstrainedQP()
+    sol = qp.run(**hyperparams).params
+    self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0,
+                        atol=1e-4)
+
+    # Check that the solutions match.
+    self.assertArraysAllClose(jnp.concatenate(sol_pytree.primal), sol.primal,
+                              atol=1e-4)
+    self.assertArraysAllClose(sol_pytree.dual_eq, sol.dual_eq, atol=1e-4)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linear_operator_test.py
+++ b/tests/linear_operator_test.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Linear Operator tests."""
+
+from absl.testing import absltest
+
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+import numpy as onp
+
+from jaxopt._src.linear_operator import FunctionalLinearOperator
+
+
+class LinearOperatorTest(jtu.JaxTestCase):
+
+  def test_matvec_and_rmatvec(self):
+    rng = onp.random.RandomState(0)
+    A = rng.randn(5, 4)
+    matvec = lambda A,x: jnp.dot(A, x)
+    x = rng.randn(4)
+    y = rng.randn(5)
+    linop_A = FunctionalLinearOperator(matvec, A)
+    mv_A, rmv_A = linop_A.matvec_and_rmatvec(x, y)
+    self.assertArraysAllClose(mv_A, jnp.dot(A, x))
+    self.assertArraysAllClose(rmv_A, jnp.dot(A.T, y))
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
!!! The goal of this PR is primarly discussions, not merging !!!

### What is new ?

Four classes are available to perform QuadraticProgramming

| Class        | Matvec, Pytree  | vmap, jit, GPU | Precision | Stable | Input |  File           | 
| ---------- |:----------:| -----:|-----------:|-----------:|----------:|--------:|
| `QuadraticProgramming`     | variable | variable | variable | variable |  `((Q,c), (A,b), (G,h))` | quadratic_prog.py | 
| `CVXPY_QP`      |    No | No | High | Yes |  `((Q,c), (A,b), (G,h))` |  cvxpy_wrapper.py      |
| `OSQP` |  No | Yes |  Low | Yes |  `((Q,c), (A,b), (G,h))` | osqp.py | 
| `BoxOSQP` |   Yes | Yes |  Low | Yes | `((Q,c), A, (l,u))` | osqp.py |
| `EqualityConstraintsQP` |   Yes | Yes | Low | No | `((Q,c), (A, b))` |  equality_quadratic_prog.py |

The function `make_kkt_optimality_fun` in `implicit_diff` have been modified to make equality constraints optional (it was mandatory before). 

The class `OSQP_to_BopxOSQP` provides functional sklearn-like API (with `fit_transform` and `inverse_transform`) to transform the format `(A, b), (G, h)` into `(A, (l, u)`. 

### Future of QuadraticProgramming

All the tests of QuadraticProgramming have been duplicated into `CVXPY_QP` (and `OSQP`), `EqualityConstraintsQP`, and even `linear_operator.py`. Nothing is lost: the coverage is the same as before. Nothing is broken. That explains the huge volume of code I added (mostly copy/paste).

Code that depends of QuadraticProgramming haven't been touch yet (to avoid breaking things).

### Observations

- `OSQP` does not support matvec/pytree because the class `OSQP_to_BoxOSQP` that performs the conversion don't. Do we need to expose this class to the user ? The reason is that `CVXPY_QP` does not suppport matvec/pytree, so `OSQP` shouldn't too (because it is meant as drop-in replacement).
- `OSQP` will most likely be less precise than `CVXPY_QP` ?(on `float32`). I hope that solution polishing in future requests could solve the issue.
- `EqualityConstraintsQP` could behave poorly on ill-posed problems and could benefit from _regularization + iterative refinement_ (like solution polishing of OSQP's paper).

### Questions

I am currently insatisfied with the current state of the API I just wrote, because I feel there are some inconsistencies but I am not sure how to handle it.

Those questions reflect choices I made in the code for this first commit.

1. should we change the names of the classes ?
2. should we change the names of the files ?
3. should we move the files in their own `quadratic_prog/` folder ?
4. does it even make sense to have that much classes with different names ?
5. should we support `Pytree/Matvec` for `OSQP`, meant to be a drop-in replacement of `CVXPY_QP` (whereas `CVXPY_QP` don't support them anyway) ?
6. should the `run()` method of `OSQP`, `CVXPY_QP` and `EqualityConstraintsQP` accept an `init_params` argument ? (currently not used, but the user must pass `None` anyway).
7. should the algorithms (all of them) accept QPs _without any constraints_ ? (currently not tested, but most of them don't)
8. should `OSQP` and `CVXPY_QP` return a state instead of `None` ?
9. even if `OSQP` is a drop-in replacement of `CVXPY_QP`, it will run on different hardware (unexpected for the user ?) and with a far worse precision.
10. how can we even explain all this mess to the user ? The array above is a first step I guess.
11. should we force the user to use only one format (for ex: `(A,b), (G, h)` or `A,(l,u)` ? Does it make sense to support pytree/matvec for all formats ? Should we support all formats ?
12. (related to 11.) should we hide everything and go for a grammar (like cvxpy) ?

### Even Deeper Questions

1. is Jaxopt a general purpose library for optimization that MUST provide _efficient algorithms_ on _all hardware_ (CPU / GPU) with _high precision_ (in this case `CVXPY_QP` is a _must-have_) ? Or is it a library that focus on speed for batchs of problems on GPU (low precision solution acceptable, `CVXPY_QP` becomes useless) ?
2. Is it a library of functionnalities, of algorithms, or of implementations ?*

**functionnalities**: I mean that the user shouldn't worry about what is running in its back, all that matters is the form of the problem. In this case the user should only have access to a `QP_Solver` class with simple interface, that have its own internal policy to select algorithms/parameters, and on which the user wouldn't have any control. This is the design choice made by cvxpy: "We know better, let us handle it for you" policy.

**algorithms**: some algorithms are more efficient than others on some problems. For this reason, we want an `EqualityConstraintsQP` class to co-exist with a more general `OSQP` class. We can imagine adding `NewtonMethod` when there are no constraints. The user can chose the most appropriate hyper-parameters and algorithm.

**implementations**: some algorithms can be implemented in different ways. For example, OSQP (ADMM for QP) is available on CPU through `CVXPY_QP` (but we lose a lot of expressivity by forcing matrices instead of the general grammar of cvxpy, that exploits sparsity). But also on GPU/TPU thanks to `OSQP`. And also with `BoxOSQP` which is really like `OSQP` but accepts matvecs/pytrees (unlike `CVXPY_QP`).  

Sorry for the lengthty PR, but those questions summarized my doubts: [relevant tweet.](https://twitter.com/girayozil/status/306836785739210752) It will be easier to proceed further once it is answered.