### PR TITLE
IterativeRefinement to improve EqualityConstrainedQP speed

### DIFF
--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -30,7 +30,13 @@ import jax
 import jax.numpy as jnp
 
 from jaxopt import implicit_diff as idf
-from jaxopt import linear_solve
+
+# Do not use jaxopt.linear_solve to avoid circular imports: use
+# jaxopt._src.linear_solve instead.
+# This allows to define linear solver with base.Solver interface,
+# and then exporting them in jaxopt.linear_solve.
+from jaxopt._src import linear_solve 
+
 from jaxopt import loop
 from jaxopt import tree_util
 

--- a/jaxopt/_src/iterative_refinement.py
+++ b/jaxopt/_src/iterative_refinement.py
@@ -1,0 +1,224 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Iterative Refinement for linear systems."""
+
+# TODO(lbethune): in the future Chebychev acceleration of Iterative Refinement
+# could be implemented:
+#   Arioli, M. and Scott, J., 2014. Chebyshev acceleration of iterative refinement.
+#   Numerical Algorithms, 66(3), pp.591-608.
+
+from typing import Any
+from typing import Callable
+from typing import NamedTuple
+from typing import Optional
+from typing import Union
+
+from dataclasses import dataclass
+from functools import partial
+
+import jax
+import jax.numpy as jnp 
+
+from jaxopt._src import loop
+from jaxopt._src import base
+from jaxopt._src import implicit_diff as idf
+from jaxopt._src.tree_util import tree_zeros_like, tree_add, tree_sub
+from jaxopt._src.tree_util import tree_add_scalar_mul, tree_scalar_mul 
+from jaxopt._src.tree_util import tree_vdot, tree_negative, tree_l2_norm
+from jaxopt._src.linear_operator import _make_linear_operator
+import jaxopt._src.linear_solve as linear_solve
+
+
+class IterativeRefinementState(NamedTuple):
+  """Named tuple containing state information.
+
+  Attributes:
+    iter_num: iteration number.
+    error: error used as stop criterion, deduced from residuals b - Ax.
+    target_residuals: residuals of the current target.
+    init: (optional) params to warm start the inner solver at next iteration.
+  """
+  iter_num: int
+  error: float
+  target_residuals: Any
+  init: Optional[Any]
+  # TODO(lbethune): in the future return the state of the internal
+  # solver (iter_num, error) as part of the current state.
+
+
+@dataclass(eq=False)
+class IterativeRefinement(base.IterativeSolver):
+  """Iterativement refinement to solve linear systems.
+
+  Solves Ax = b up to high accuracy with low precision solver.
+
+  The algorithm starts with :math:`r_0, x_0 = b, 0` and solves iteratively::
+
+    \begin{aligned}
+    \text{solve for x}  \bar{A} x &= r_{t-1}\\
+                        x_t &= x_{t-1} + x\\
+                        r_t &= b - A x_t
+    \end{aligned}
+  where :math:`\bar{A}` is some approximation of A, with preferably
+  better preconditonning than A.
+
+  This method has the advantage to converge even if the solve step is inaccurate.  
+  This is particularly useful for ill-posed problems, with strong regularization on
+  :math:`\bar{A}`, in ``float32`` environment, or with solvers that struggle to converge.
+
+  Attributes:
+    solve: a Callable that accepts A as first argument, b as second,
+      and a warm start ``init`` as third argument.
+      This solver can be inaccurate and run with low precision.
+    matvec: (optional) a Callable matvec_A(params_A, x).
+      By default, matvec_A(A, x) = tree_dot(A, x), where tree pytree A = params_A matches x structure.
+    matvec_A_bar: (optional) a Callable.
+      If None, then :math:`\bar{A}=A`. Otherwise, a Callable matvec_A_bar(x).
+    maxiter: maximum number of iterations (default: 10).
+    tol: absolute tolerance for stoping criterion (default: 1e-7).
+    verbose: If verbose=1, print error at each iteration.
+    implicit_diff: whether to enable implicit diff or autodiff of unrolled iterations.
+    implicit_diff_solve: the linear system solver to use.
+    jit: whether to JIT-compile the optimization loop (default: "auto").
+    unroll: whether to unroll the optimization loop (default: "auto")
+
+  References:
+    
+    [1] J. H. Wilkinson. Rounding Errors in Algebraic Processes. Prentice Hall, Englewood Cliffs, NJ, 1963.  
+      
+    [2] Moler, C.B., 1967. Iterative refinement in floating point. Journal of the ACM (JACM), 14(2), pp.316-321.  
+      
+    [3] Wikipedia contributors, "Iterative refinement,"
+        Wikipedia, The Free Encyclopedia,
+        https://en.wikipedia.org/w/index.php?title=Iterative_refinement&oldid=1055633064 (accessed December 3, 2021).
+  """
+  matvec_A: Optional[Callable] = None
+  matvec_A_bar: Optional[Callable] = None
+  solve: Callable = partial(linear_solve.solve_gmres, ridge=1e-6)
+  maxiter: int = 10
+  tol: float = 1e-7
+  verbose: int = 0
+  implicit_diff_solve: Optional[Callable] = None
+  jit: base.AutoOrBoolean = "auto"
+  unroll: base.AutoOrBoolean = "auto"
+
+  def init_state(self,
+                 init_params: Any,
+                 params_A: Any,
+                 b: Any,
+                 params_A_bar: Any = None):
+    return IterativeRefinementState(
+      iter_num=jnp.asarray(0),
+      error=jnp.asarray(jnp.inf),
+      target_residuals=b,
+      init=init_params)
+
+  def init_params(self,
+                  params_A: Any,
+                  b: Any,
+                  params_A_bar: Any = None):
+    return tree_zeros_like(b)
+
+  def update(self,
+             params: Any,
+             state: IterativeRefinementState,
+             params_A: Any,
+             b: Any,
+             params_A_bar: Optional[Any] = None):
+    if self._copy_params_A:
+      params_A_bar = params_A
+
+    A = self.matvec_A(params_A)
+    A_bar = self.matvec_A_bar(params_A_bar)
+
+    # TODO(lbethune): support preconditioners ?
+    # Could it be done by user with partial(solver, M=precond) ?
+    residual_sol = self.solve(A_bar, state.target_residuals, init=state.init)
+
+    params = tree_add(params, residual_sol)
+
+    target_residuals = tree_sub(b, A(params))
+    error = tree_l2_norm(target_residuals)
+
+    state = IterativeRefinementState(
+      iter_num=state.iter_num+1,
+      error=error,
+      target_residuals=target_residuals,
+      init=None)
+    
+    return base.OptStep(params, state)
+
+  def run(self,
+          init_params: Optional[Any],
+          params_A: Any,
+          b: Any,
+          params_A_bar: Optional[Any] = None):
+    if init_params is None:
+      init_params = self.init_params(params_A, b, params_A_bar)
+    return super().run(init_params, params_A, b, params_A_bar)
+    
+  def optimality_fun(self,
+                     params: Any,
+                     params_A: Any,
+                     b: Any,
+                     params_A_bar: Optional[Any] = None):
+    del params_A_bar  # unused
+    A = self.matvec_A(params_A)
+    return tree_sub(b, A(params))
+
+  def l2_optimality_error(self,
+                          params: Any,
+                          params_A: Any,
+                          b: Any,
+                          params_A_bar: Optional[Any] = None):
+    del params_A_bar  # unused
+    return tree_l2_norm(self.optimality_fun(params, params_A, b))
+
+  def __post_init__(self):
+    self._copy_params_A = False
+    if self.matvec_A_bar is None:
+      self.matvec_A_bar = self.matvec_A
+      self._copy_params_A = True
+    
+    self.matvec_A = _make_linear_operator(self.matvec_A)
+    self.matvec_A_bar = _make_linear_operator(self.matvec_A_bar)
+
+
+def solve_iterative_refinement(matvec: Callable,
+                               b: Any,
+                               init: Optional[Any] = None,
+                               maxiter: int = 10,
+                               tol: float = 1e-7,
+                               solve: Callable = linear_solve.solve_gmres,
+                               **kwargs) -> Any:
+  """Solves ``A x = b`` using iterative refinement.
+
+  Args:
+    matvec: product between ``A`` and a vector.
+    b: pytree.
+    maxiter: maximum number of refinement steps (default: 10).
+    tol: absolute tolerance residuals (default: 1e-7).
+    solve: optional solve function (default: linear_solve.solve_gmres).
+    kwargs: additional parameters for IterativeRefinement.
+
+  Returns:
+    Pytree with the same structure as ``b``.
+  """
+  iterative_refinement = IterativeRefinement(matvec_A=lambda _,x: matvec(x),
+                                             solve=solve,
+                                             maxiter=maxiter,
+                                             tol=tol,
+                                             **kwargs)
+  return iterative_refinement.run(init, params_A=None, b=b)[0]
+

--- a/jaxopt/_src/linear_operator.py
+++ b/jaxopt/_src/linear_operator.py
@@ -39,7 +39,7 @@ class DenseLinearOperator:
     return self.matvec(x), self.rmatvec(x, y)
 
   def normal_matvec(self, x):
-    """Computes A^T A x from matvec(x) = A x."""
+    """Computes A^T A x."""
     return self.rmatvec(x, self.matvec(x))
 
   def diag(self):

--- a/jaxopt/_src/linear_solve.py
+++ b/jaxopt/_src/linear_solve.py
@@ -124,6 +124,7 @@ def _normal_matvec(matvec, x):
 def solve_normal_cg(matvec: Callable,
                     b: Any,
                     ridge: Optional[float] = None,
+                    init: Optional[Any] = None,
                     **kwargs) -> Any:
   """Solves the normal equation ``A^T A x = A^T b`` using conjugate gradient.
 
@@ -134,6 +135,7 @@ def solve_normal_cg(matvec: Callable,
     matvec: product between ``A`` and a vector.
     b: pytree.
     ridge: optional ridge regularization.
+    init: optional initialization to be used by normal conjugate gradient.
     **kwargs: additional keyword arguments for solver.
 
   Returns:
@@ -154,6 +156,7 @@ def solve_normal_cg(matvec: Callable,
 def solve_gmres(matvec: Callable,
                 b: Any,
                 ridge: Optional[float] = None,
+                init: Optional[Any] = None,
                 tol: float = 1e-5,
                 **kwargs) -> Any:
   """Solves ``A x = b`` using gmres.
@@ -162,6 +165,7 @@ def solve_gmres(matvec: Callable,
     matvec: product between ``A`` and a vector.
     b: pytree.
     ridge: optional ridge regularization.
+    init: optional initialization to be used by gmres.
     **kwargs: additional keyword arguments for solver.
 
   Returns:
@@ -175,6 +179,7 @@ def solve_gmres(matvec: Callable,
 def solve_bicgstab(matvec: Callable,
                    b: Any,
                    ridge: Optional[float] = None,
+                   init: Optional[Any] = None,
                    **kwargs) -> Any:
   """Solves ``A x = b`` using bicgstab.
 
@@ -182,6 +187,7 @@ def solve_bicgstab(matvec: Callable,
     matvec: product between ``A`` and a vector.
     b: pytree.
     ridge: optional ridge regularization.
+    init: optional initialization to be used by bicgstab.
     **kwargs: additional keyword arguments for solver.
 
   Returns:

--- a/jaxopt/_src/tree_util.py
+++ b/jaxopt/_src/tree_util.py
@@ -58,6 +58,14 @@ def tree_vdot(tree_x, tree_y):
   return tree_reduce(operator.add, vdots)
 
 
+def tree_dot(tree_x, tree_y):
+  """Compute leaves-wise dot product between pytree of arrays.
+  
+  Useful to store block diagonal linear operators: each leaf of the tree
+  corresponds to a block."""
+  return tree_map(jnp.dot, tree_x, tree_y)
+
+
 def tree_sum(tree_x):
   """Compute sum(tree_x)."""
   sums = tree_map(jnp.sum, tree_x)

--- a/jaxopt/linear_solve.py
+++ b/jaxopt/linear_solve.py
@@ -18,3 +18,4 @@ from jaxopt._src.linear_solve import solve_cg
 from jaxopt._src.linear_solve import solve_normal_cg
 from jaxopt._src.linear_solve import solve_gmres
 from jaxopt._src.linear_solve import solve_bicgstab
+from jaxopt._src.iterative_refinement import solve_iterative_refinement

--- a/tests/iterative_refinement_test.py
+++ b/tests/iterative_refinement_test.py
@@ -1,0 +1,122 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+
+from absl.testing import absltest
+
+import jax
+from jax import test_util as jtu
+import jax.numpy as jnp
+from jax.test_util import check_grads
+
+from jaxopt._src import linear_solve as _linear_solve
+from jaxopt import linear_solve
+
+import numpy as onp
+from jaxopt._src.iterative_refinement import IterativeRefinement
+
+
+class IterativeRefinementTest(jtu.JaxTestCase):
+
+  def test_simple_system(self):
+    onp.random.seed(0)
+    n = 20
+    A = onp.random.rand(n, n)
+    b = onp.random.randn(n)
+
+    low_acc = 1e-1
+    high_acc = 1e-5
+
+    # Heavily regularized low acuracy solver.
+    inner_solver = partial(_linear_solve.solve_gmres, tol=low_acc, ridge=1e-3)
+
+    solver = IterativeRefinement(solve=inner_solver, tol=high_acc, maxiter=10)
+    x, state = solver.run(None, A, b)
+    self.assertLess(state.error, high_acc)
+
+    x_approx = inner_solver(lambda x: jnp.dot(A, x), b)
+    error_inner_solver = solver.l2_optimality_error(x_approx, A, b)
+    # High accuracy solution obtained from low accuracy solver.
+    self.assertLess(state.error, error_inner_solver)
+
+  def test_ill_posed_problem(self):
+    onp.random.seed(0)
+    n = 10
+    e = 5
+
+    # duplicated rows.
+    A = onp.random.rand(e, n)
+    A = jnp.concatenate([A, A], axis=0)
+    b = onp.random.randn(e)
+    b = jnp.concatenate([b, b], axis=0)
+
+    low_acc = 1e-1
+    high_acc = 1e-3
+
+    # Heavily regularized low acuracy solver.
+    inner_solver = partial(_linear_solve.solve_gmres, tol=low_acc, ridge=5e-2)
+
+    solver = IterativeRefinement(solve=inner_solver, tol=high_acc, maxiter=30)
+    x, state = solver.run(init_params=None, params_A=A, b=b)
+    self.assertLess(state.error, high_acc)
+
+    x_approx = inner_solver(lambda x: jnp.dot(A, x), b)
+    error_inner_solver = solver.l2_optimality_error(x_approx, A, b)
+    # High accuracy solution obtained from low accuracy solver.
+    self.assertLess(state.error, error_inner_solver)
+
+  def test_perturbed_system(self):
+    onp.random.seed(0)
+    n = 20
+
+    A = onp.random.rand(n, n)  # invertible matrix (with high probability).
+
+    noise = onp.random.randn(n, n)
+    sigma = 0.05
+    A_bar = A + sigma * noise  # perturbed system.
+    
+    expected = onp.random.randn(n)
+    b = A @ expected  # unperturbed target.
+
+    high_acc = 1e-3
+    solver = IterativeRefinement(matvec_A=None, matvec_A_bar=jnp.dot,
+                                 tol=high_acc, maxiter=100)
+    x, state = solver.run(init_params=None, params_A=A, b=b, params_A_bar=A_bar)
+    self.assertLess(state.error, high_acc)
+    self.assertArraysAllClose(x, expected, rtol=5e-2)
+
+  def test_implicit_diff(self):
+    onp.random.seed(17)
+    n = 20
+    A = onp.random.rand(n, n)
+    b = onp.random.randn(n)
+
+    low_acc = 1e-1
+    high_acc = 1e-5
+
+    # Heavily regularized low acuracy solver.
+    inner_solver = partial(_linear_solve.solve_gmres, tol=low_acc, ridge=1e-3)
+    solver = IterativeRefinement(solve=inner_solver, tol=high_acc, maxiter=10)
+
+    def solve_run(A, b):
+      x, state = solver.run(init_params=None, params_A=A, b=b)
+      return x
+
+    check_grads(solve_run, args=(A, b), order=1, modes=['rev'], eps=1e-3)
+
+
+if __name__ == "__main__":
+  jax.config.update("jax_enable_x64", False)  # low precision environment.
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linear_solve_test.py
+++ b/tests/linear_solve_test.py
@@ -66,7 +66,9 @@ class LinearSolveTest(jtu.JaxTestCase):
     matvec = lambda x: jnp.dot(A, x)
     x = linear_solve.solve_lu(matvec, b)
     x2 = jax.numpy.linalg.solve(A, b)
+    x3 = linear_solve.solve_iterative_refinement(matvec, b)
     self.assertArraysAllClose(x, x2)
+    self.assertArraysAllClose(x, x3)
 
     # Tensor case.
     A = rng.randn(5, 3, 5, 3)
@@ -78,7 +80,9 @@ class LinearSolveTest(jtu.JaxTestCase):
 
     x = linear_solve.solve_lu(matvec, b)
     x2 = linear_solve.solve_gmres(matvec, b)
+    x3 = linear_solve.solve_iterative_refinement(matvec, b)
     self.assertArraysAllClose(x, x2, atol=1e-4)
+    self.assertArraysAllClose(x, x3, atol=1e-4)
 
   def test_solve_dense_psd(self):
     rng = onp.random.RandomState(0)
@@ -104,9 +108,11 @@ class LinearSolveTest(jtu.JaxTestCase):
     x2 = linear_solve.solve_normal_cg(matvec, b)
     x3 = linear_solve.solve_gmres(matvec, b)
     x4 = linear_solve.solve_bicgstab(matvec, b)
+    x5 = linear_solve.solve_iterative_refinement(matvec, b)
     self.assertArraysAllClose(x, x2, atol=1e-4)
     self.assertArraysAllClose(x, x3, atol=1e-4)
     self.assertArraysAllClose(x, x4, atol=1e-4)
+    self.assertArraysAllClose(x, x5, atol=1e-4)
 
   def test_solve_sparse_ridge(self):
     rng = onp.random.RandomState(0)


### PR DESCRIPTION
## What is new ?

The class `IterativeRefinement` is a wrapper to increases the precision of linear system solvers: by minimizing the residuals iteratively a high accuracy solution can be obtained from a low accuracy solver, which is useful in `float32` for ill-posed problems.

This functionnality is also available through a function in `linear_solve`, that mimic the interface of `solve_gmres,solve_bicgstab` etc...

Iterative Refinement solves `Ax=b` with the following recursion:

![iterative](https://user-images.githubusercontent.com/8568881/144243008-50168b25-e900-469f-812f-d781b5e89c81.png)

Where `x_0=0` and `r_0=b`. The matrix `A_bar` can be any (regularized) approximation of `A`. The linear solver on the first step can be inaccurate, as long as computing the residuals `b-Ax` is accurate.

The user can specify its own `A_bar`; otherwise we take `A_bar=A`.

## Link with EqualityConstrainedQP

This allows `EqualityConstrainedQP` to solve badly scaled problems (see new test).
The following attributes have been added to EqualityConstrainedQP:

- refine_regularization: (optional) a positive float specifying the strength of regularization.
- refine_maxiter: maximum number of refinement steps when refine_regularization is not None.

## Question

Under which section should we document the class `IterativeRefinement` ? Do we need a `Linear Solvers` section ? Or under `constrained optimization` ? Finding a feasible point (constrained problem, without objective) can be turned into an optimization problem (unconstrained minimization of residuals).