### PR TITLE
Prevent recompilation of loops in `solver.run` if executing without jit.

### DIFF
--- a/jaxopt/_src/cvxpy_wrapper.py
+++ b/jaxopt/_src/cvxpy_wrapper.py
@@ -82,7 +82,7 @@ def _make_cvxpy_qp_optimality_fun():
   return idf.make_kkt_optimality_fun(obj_fun, eq_fun, ineq_fun)
 
 
-@dataclass
+@dataclass(eq=False)
 class CvxpyQP(base.Solver):
   """Wraps CVXPY's quadratic solver with implicit diff support.
 

--- a/jaxopt/_src/eq_qp.py
+++ b/jaxopt/_src/eq_qp.py
@@ -62,8 +62,8 @@ def _make_eq_qp_optimality_fun(matvec_Q, matvec_A):
   return optimality_fun
 
 
-@dataclass
-class EqualityConstrainedQP():
+@dataclass(eq=False)
+class EqualityConstrainedQP(base.Solver):
   """Quadratic programming with equality constraints only.
 
   Supports implicit differentiation, matvec and pytrees.

--- a/jaxopt/_src/osqp.py
+++ b/jaxopt/_src/osqp.py
@@ -169,7 +169,7 @@ class JacobiPreconditioner(BoxOSQPPreconditioner):
     return params_precond[:-1] + (rho_bar,)
 
 
-@dataclass
+@dataclass(eq=False)
 class BoxOSQP(base.IterativeSolver):
   """Operator Splitting Solver for Quadratic Programs.
 

--- a/jaxopt/_src/polyak_sgd.py
+++ b/jaxopt/_src/polyak_sgd.py
@@ -43,7 +43,7 @@ class PolyakSGDState(NamedTuple):
   velocity: Optional[Any]
 
 
-@dataclasses.dataclass(eq=True)
+@dataclasses.dataclass(eq=False)
 class PolyakSGD(base.StochasticSolver):
   """SGD with Polyak step size.
 

--- a/jaxopt/_src/projected_gradient.py
+++ b/jaxopt/_src/projected_gradient.py
@@ -134,4 +134,3 @@ class ProjectedGradient(base.IterativeSolver):
                                 has_aux=self.has_aux,
                                 jit=self.jit,
                                 unroll=self.unroll)
-

--- a/jaxopt/_src/proximal_gradient.py
+++ b/jaxopt/_src/proximal_gradient.py
@@ -80,7 +80,6 @@ def fista_line_search(
                          unroll=unroll, jit=jit)
 
 
-
 class ProxGradState(NamedTuple):
   """Named tuple containing state information."""
   iter_num: int

--- a/jaxopt/_src/quadratic_prog.py
+++ b/jaxopt/_src/quadratic_prog.py
@@ -156,7 +156,7 @@ def _make_quadratic_prog_optimality_fun(matvec_Q, matvec_A):
   return idf.make_kkt_optimality_fun(obj_fun, eq_fun, ineq_fun)
 
 
-@dataclass
+@dataclass(eq=False)
 class QuadraticProgramming(base.Solver):
   """Quadratic programming solver (deprecated).
 

--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -194,7 +194,7 @@ def pytree_topology_from_example(x_jnp: Any) -> PyTreeTopology:
   return PyTreeTopology(treedef=treedef, shapes=shapes, dtypes=dtypes)
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyWrapper(base.Solver):
   """Wraps over `scipy.optimize` methods with PyTree and implicit diff support.
 
@@ -228,7 +228,7 @@ class ScipyWrapper(base.Solver):
     self.run = decorator(self.run)
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyMinimize(ScipyWrapper):
   """`scipy.optimize.minimize` wrapper
 
@@ -314,7 +314,7 @@ class ScipyMinimize(ScipyWrapper):
       self._value_and_grad_fun = jax.jit(self._value_and_grad_fun)
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyBoundedMinimize(ScipyMinimize):
   """`scipy.optimize.minimize` wrapper.
 
@@ -363,7 +363,7 @@ class ScipyBoundedMinimize(ScipyMinimize):
     return self._run(init_params, bounds, *args, **kwargs)
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyRootFinding(ScipyWrapper):
   """`scipy.optimize.root` wrapper.
 
@@ -468,7 +468,7 @@ LS_DEFAULT_OPTIONS = {
 }
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyLeastSquares(ScipyWrapper):
   """Wraps over `scipy.optimize.least_squares` with PyTree & imp. diff support.
 
@@ -601,7 +601,7 @@ class ScipyLeastSquares(ScipyWrapper):
       self._grad_cost_fun = jax.jit(self._grad_cost_fun)
 
 
-@dataclass
+@dataclass(eq=False)
 class ScipyBoundedLeastSquares(ScipyLeastSquares):
   """Wraps over `scipy.optimize.least_squares` with PyTree & imp. diff support.
 


### PR DESCRIPTION
#### Context

An issue was found whereby executing the `run` method of `IterativeSolver`s without `jit` would cause `lax.while_loop` or `lax.scan` to be retraced in each subsequence call. This was due to `cond_fun` and `body_fun` being (re)defined inside the private method `_run` of `IterativeSolver`.

#### Solution and caveats

The functions `cond_fun` and `body_fun` have been defined as methods of `IterativeSolver`. This solved the retracing issues. However, it causes two important changes in the way subclasses of `IterativeSolver` behave, namely
1. Methods of `IterativeSolver` must support serving as inputs to JAX transforms directly (see point below).
2. Positional and keyword arguments of `run` are no longer passed to `body_fun` with a closure but rather as explicit inputs. Hence, they must support JAX tracing.

#### JAX-transforming methods of `IterativeSolver` / bypassing a Python 3.7 dataclass issue

We found that applying JAX transformations such as `jax.jit` directly to methods of `IterativeSolver` raises a `TypeError: unhashable type` exception in Python 3.7 whenever the solver is a Python dataclass with `eq=True`. This problem does *not* occur in Python 3.8 nor Python 3.9. The issue is particularly problematic for this PR, as the same limitation occurs when passing the newly-defined-as-methods `body_fun` and `cond_fun` to `lax.while_loop` or `lax.scan`.

*To solve this issue, we temporarily set `eq=False` in all JAXopt solvers. This might change in the future if either an alternative solution is found, or support for Python 3.7 is eventually dropped.*

#### Other

This PR is joint work with @mblondel and @Algue-Rythme.