### PR TITLE
Add OSQP to SVMs examples.

### DIFF
--- a/examples/constrained/binary_kernel_svm_with_intercept.py
+++ b/examples/constrained/binary_kernel_svm_with_intercept.py
@@ -19,52 +19,63 @@ Binary kernel SVM with intercept.
 The dual objective of binary kernel SVMs with an intercept contains both
 box constraints and an equality constraint, making it challenging to solve.
 The state-of-the-art algorithm to solve this objective is SMO (Sequential
-minimal optimization). We nevertheless demonstrate in this example how to solve
+minimal optimization). 
+
+We nevertheless demonstrate in this example how to solve
 it by projected gradient descent, by projecting on the constraint set
-using projection_box_section.
+using projection_box_section.  
+  
+Since the dual objective is a Quadratic Program we show how to solve
+it with BoxOSQP too.
 """
 
 from absl import app
+from absl import flags
+
+import jax
 import jax.numpy as jnp
 from jaxopt import projection
 from jaxopt import ProjectedGradient
+from jaxopt import BoxOSQP
+
 import numpy as onp
 from sklearn import datasets
 from sklearn import preprocessing
 from sklearn import svm
 
 
-def objective_fun(beta, lam, K, y):
-  """Dual objective of binary kernel SVMs with intercept."""
-  # The dual objective is:
-  # fun(beta) = 0.5 beta^T K beta - beta^T y
-  # subject to
-  # sum(beta) = 0
-  # 0 <= beta_i <= C if y_i = 1
-  # -C <= beta_i <= 0 if y_i = -1
-  # where C = 1.0 / lam
-  return 0.5 * jnp.dot(beta, jnp.dot(K, beta)) - jnp.dot(beta, y)
+flags.DEFINE_float("lam", 0.5, "Regularization parameter. Must be positive.")
+flags.DEFINE_float("tol", 1e-6, "Tolerance of solvers.")
+flags.DEFINE_integer("num_samples", 30, "Size of train set.")
+flags.DEFINE_integer("num_features", 5, "Features dimension.")
+flags.DEFINE_bool("verbose", False, "Verbosity.")
+FLAGS = flags.FLAGS
 
 
-def binary_kernel_svm_skl(K, y, lam, tol=1e-5):
-  svc = svm.SVC(kernel="precomputed", C=1.0 / lam).fit(K, y)
+def binary_kernel_svm_skl(X, y, C):
+  print(f"Solve SVM with sklearn.svm.SVC: ")
+  K = jnp.dot(X, X.T)
+  svc = svm.SVC(kernel="precomputed", C=C, tol=FLAGS.tol).fit(K, y)
   dual_coef = onp.zeros(K.shape[0])
   dual_coef[svc.support_] = svc.dual_coef_[0]
   return dual_coef
 
 
-def main(argv):
-  del argv
+def binary_kernel_svm_pg(X, y, C):
+  print(f"Solve SVM with Projected Gradient: ")
 
-  # Prepare data.
-  X, y = datasets.make_classification(n_samples=20, n_features=5,
-                                      n_informative=3, n_classes=2,
-                                      random_state=0)
-  X = preprocessing.Normalizer().fit_transform(X)
-  y = y * 2 - 1  # Transform labels from {0, 1} to {-1, 1}.
-  lam = 1.0
-  C = 1./ lam
-  K = jnp.dot(X, X.T)  # Use a linear kernel.
+  def objective_fun(beta, X, y):
+    """Dual objective of binary kernel SVMs with intercept."""
+    # The dual objective is:
+    # fun(beta) = 0.5 beta^T K beta - beta^T y
+    # subject to
+    # sum(beta) = 0
+    # 0 <= beta_i <= C if y_i = 1
+    # -C <= beta_i <= 0 if y_i = -1
+    # where C = 1.0 / lam
+    # and K = X X^T
+    Kbeta = jnp.dot(X, jnp.dot(X.T, beta))
+    return 0.5 * jnp.dot(beta, Kbeta) - jnp.dot(beta, y)
 
   # Define projection operator.
   w = jnp.ones(X.shape[0])
@@ -77,14 +88,88 @@ def main(argv):
 
   # Run solver.
   beta_init = jnp.ones(X.shape[0])
-  solver = ProjectedGradient(fun=objective_fun, projection=proj,
-                            tol=1e-3, maxiter=500)
-  beta_fit = solver.run(beta_init, hyperparams_proj=C, lam=lam, K=K, y=y).params
+  solver = ProjectedGradient(fun=objective_fun,
+                             projection=proj,
+                             tol=FLAGS.tol, maxiter=500, verbose=FLAGS.verbose)
+  beta_fit = solver.run(beta_init, hyperparams_proj=C, X=X, y=y).params
 
-  # Compare the obtained dual coefficients with sklearn.
-  beta_fit_skl = binary_kernel_svm_skl(K, y, lam)
-  print(beta_fit)
-  print(beta_fit_skl)
+  return beta_fit
+
+
+def binary_kernel_svm_osqp(X, y, C):
+  # The dual objective is:
+  # fun(beta) = 0.5 beta^T K beta - beta^T y
+  # subject to
+  # sum(beta) = 0
+  # 0 <= beta_i <= C if y_i = 1
+  # -C <= beta_i <= 0 if y_i = -1
+  # where C = 1.0 / lam
+
+  print(f"Solve SVM with OSQP: ")
+
+  def matvec_Q(X, beta):
+    return jnp.dot(X, jnp.dot(X.T,  beta))
+  
+  # There qre two types of constraints:
+  #   0 <= y_i * beta_i <= C     (1)
+  # and:
+  #   sum(beta) = 0              (2)
+  # The first one involves the identity matrix over the betas.
+  # The second one involves their sum (i.e dot product with vector full of 1).
+  # We take advantage of matvecs to avoid materializing A in memory.
+  # We return a tuple whose entries correspond each type of constraint.
+  def matvec_A(_, beta):
+    return beta, jnp.sum(beta)
+  
+  # l, u must have same shape than matvec_A's output.
+  l = -jax.nn.relu(-y * C), 0.
+  u =  jax.nn.relu( y * C), 0.
+
+  hyper_params = dict(params_obj=(X, -y), params_eq=None, params_ineq=(l, u))
+  osqp = BoxOSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, tol=FLAGS.tol)
+  params, _ = osqp.run(init_params=None, **hyper_params)
+  beta = params.primal[0]
+
+  return beta
+
+
+def print_svm_result(beta, threshold=1e-4):
+  # Here the vector `beta` of coefficients is signed:
+  # its sign depends of the true label of the corresponding example.
+  # Hence we use jnp.abs() to detect support vectors.
+  is_support_vectors = jnp.abs(beta) > threshold
+  print(f"Beta: {beta}")
+  print(f"Support vector indices: {onp.where(is_support_vectors)[0]}")
+  print("")
+
+
+def main(argv):
+  del argv
+
+  num_samples = FLAGS.num_samples
+  num_features = FLAGS.num_features
+
+  # Prepare data.
+  X, y = datasets.make_classification(n_samples=num_samples, n_features=num_features,
+                                      n_classes=2,
+                                      random_state=0)
+  X = preprocessing.Normalizer().fit_transform(X)
+  y = jnp.array(y * 2. - 1)  # Transform labels from {0, 1} to {-1., 1.}.
+
+  lam = FLAGS.lam
+  C = 1./ lam
+
+  # Compare the obtained dual coefficients.
+  beta_fit_osqp = binary_kernel_svm_osqp(X, y, C)
+  print_svm_result(beta_fit_osqp)
+
+  beta_fit_pg = binary_kernel_svm_pg(X, y, C)
+  print_svm_result(beta_fit_pg)
+
+  beta_fit_skl = binary_kernel_svm_skl(X, y, C)
+  print_svm_result(beta_fit_skl)
+  
 
 if __name__ == "__main__":
+  jax.config.update("jax_platform_name", "cpu")
   app.run(main)

--- a/examples/constrained/multiclass_linear_svm.py
+++ b/examples/constrained/multiclass_linear_svm.py
@@ -15,59 +15,130 @@
 """
 Multiclass linear SVM (without intercept).
 ==========================================
+
+This quadratic program can be solved either with OSQP or with block coordinate descent.
+  
+Reference:  
+  
+  Crammer, K. and Singer, Y., 2001. On the algorithmic implementation of multiclass kernel-based vector machines.
+  Journal of machine learning research, 2(Dec), pp.265-292.
 """
 
 from absl import app
+from absl import flags
+
+import jax
 import jax.numpy as jnp
+
 from jaxopt import BlockCoordinateDescent
+from jaxopt import OSQP
 from jaxopt import objective
 from jaxopt import projection
 from jaxopt import prox
+
 from sklearn import datasets
 from sklearn import preprocessing
 from sklearn import svm
 
 
-def multiclass_linear_svm_skl(X, y, l2reg, tol=1e-5):
+flags.DEFINE_float("tol", 1e-5, "Tolerance of solvers.")
+flags.DEFINE_float("l2reg", 1000., "Regularization parameter. Must be positive.")
+flags.DEFINE_integer("num_samples", 20, "Size of train set.")
+flags.DEFINE_integer("num_features", 5, "Features dimension.")
+flags.DEFINE_integer("num_classes", 3, "Number of classes.")
+flags.DEFINE_bool("verbose", False, "Verbosity.")
+FLAGS = flags.FLAGS
+
+
+def multiclass_linear_svm_skl(X, y, l2reg):
+  print("Solve multiclass SVM with sklearn.svm.LinearSVC:")
   svc = svm.LinearSVC(loss="hinge", dual=True, multi_class="crammer_singer",
-                      C=1.0 / l2reg, fit_intercept=False, tol=tol).fit(X, y)
+                      C=1.0 / l2reg, fit_intercept=False,
+                      tol=FLAGS.tol, max_iter=100*1000).fit(X, y)
   return svc.coef_.T
+
+
+def multiclass_linear_svm_bcd(X, Y, l2reg):
+  print("Block coordinate descent solution:")
+
+  # Set up parameters.
+  block_prox = prox.make_prox_from_projection(projection.projection_simplex)
+  fun = objective.multiclass_linear_svm_dual
+  data = (X, Y)
+  beta_init = jnp.ones((X.shape[0], Y.shape[-1])) / Y.shape[-1]
+
+  # Run solver.
+  bcd = BlockCoordinateDescent(fun=fun, block_prox=block_prox,
+                               maxiter=10*1000, tol=FLAGS.tol)
+  sol = bcd.run(beta_init, hyperparams_prox=None, l2reg=FLAGS.l2reg, data=data)
+  return sol.params
+
+
+def multiclass_linear_svm_osqp(X, Y, l2reg):
+  # We solve the problem
+  #
+  #   minimize 0.5/l2reg beta X X.T beta - (1. - Y)^T beta - 1./l2reg (Y^T X) X^T beta
+  #   under        beta >= 0
+  #         sum_i beta_i = 1
+  #
+  print("OSQP solution solution:")
+
+  def matvec_Q(X, beta):
+    return 1./l2reg * jnp.dot(X, jnp.dot(X.T, beta))
+
+  linear_part = - (1. - Y) - 1./l2reg * jnp.dot(X, jnp.dot(X.T, Y))
+
+  def matvec_A(_, beta):
+    return jnp.sum(beta, axis=-1)
+
+  def matvec_G(_, beta):
+    return -beta
+
+  b = jnp.ones(X.shape[0])
+  h = jnp.zeros_like(Y)
+
+  osqp = OSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, matvec_G=matvec_G, tol=FLAGS.tol, maxiter=10*1000)
+  hyper_params = dict(params_obj=(X, linear_part),
+                      params_eq=(None, b),
+                      params_ineq=(None, h))
+  
+  init_params = osqp._box_osqp.init_params(init_x=None, **hyper_params)
+  sol, _ = osqp.run(init_params=None, **hyper_params)
+  return sol.primal
 
 
 def main(argv):
   del argv
 
   # Generate data.
-  n_samples, n_classes = 20, 3
-  X, y = datasets.make_classification(n_samples=n_samples, n_features=5,
-                                      n_informative=3, n_classes=n_classes,
-                                      random_state=0)
+  num_samples = FLAGS.num_samples
+  num_features = FLAGS.num_features
+  num_classes = FLAGS.num_classes
+
+  X, y = datasets.make_classification(n_samples=num_samples, n_features=num_features,
+                                      n_informative=3, n_classes=num_classes, random_state=0)
+  X = preprocessing.Normalizer().fit_transform(X)
   Y = preprocessing.LabelBinarizer().fit_transform(y)
   Y = jnp.array(Y)
 
-  # Set up parameters.
-  block_prox = prox.make_prox_from_projection(projection.projection_simplex)
-  fun = objective.multiclass_linear_svm_dual
-  data = (X, Y)
-  l2reg = 1000.0
-  beta_init = jnp.ones((n_samples, n_classes)) / n_classes
-
-  # Run solver.
-  bcd = BlockCoordinateDescent(fun=fun, block_prox=block_prox,
-                               maxiter=3500, tol=1e-5)
-  sol = bcd.run(beta_init, hyperparams_prox=None, l2reg=l2reg, data=data)
+  l2reg = FLAGS.l2reg
 
   # Compare against sklearn.
-  W_skl = multiclass_linear_svm_skl(X, y, l2reg)
-  W_fit = jnp.dot(X.T, (Y - sol.params)) / l2reg
+  W_osqp = multiclass_linear_svm_osqp(X, Y, l2reg)
+  W_fit_osqp = jnp.dot(X.T, (Y - W_osqp)) / l2reg
+  print(W_fit_osqp)
+  print()
 
-  print("scikit-learn solution:")
+  W_bcd = multiclass_linear_svm_bcd(X, Y, l2reg)
+  W_fit_bcd  = jnp.dot(X.T, (Y - W_bcd)) / l2reg
+  print(W_fit_bcd)
+  print()
+
+  W_skl = multiclass_linear_svm_skl(X, y, l2reg)
   print(W_skl)
   print()
 
-  print("BlockCoordinateDescent solution:")
-  print(W_fit)
-
 
 if __name__ == "__main__":
+  jax.config.update("jax_platform_name", "cpu")
   app.run(main)


### PR DESCRIPTION
The two examples of SVM `binary_kernel_svm_with_intercept` and `multiclass_linear_svm` are now solved with ``BoxOSQP`` and ``OSQP`` on toy datasets.

The `binary_kernel_svm_with_intercept` example also exhibit a `LinearKernel` class that illustrates a possible API for kernels. See also the (unmerged) branch: https://github.com/Algue-Rythme/jaxopt/blob/svmfast/jaxopt/_src/kernels.py