### PR TITLE
add citing information to the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,25 @@ License
 
 JAXopt is licensed under the Apache 2.0 License.
 
+
+Citing
+------
+
+If this software is useful for you, please consider citing 
+`the paper <https://arxiv.org/abs/2105.15183>`_ that describes
+its implicit differentiation framework:
+
+.. code-block:: bibtex
+
+   @article{jaxopt_implicit_diff,
+   title={Efficient and Modular Implicit Differentiation},
+   author={Blondel, Mathieu and Berthet, Quentin and Cuturi, Marco and Frostig, Roy 
+      and Hoyer, Stephan and Llinares-L{\'o}pez, Felipe and Pedregosa, Fabian 
+      and Vert, Jean-Philippe},
+   journal={arXiv preprint arXiv:2105.15183},
+   year={2021}
+
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
I just realized that the citing information is only in the github README but not in the online documentation. It seems important to me to add it to the documentation, since non-dev users might never read the github README page