### PR TITLE
customize the VJP of custom-root functions to higher order

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 Version 0.3
 -----------
 
+Bug fixes and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `Support implicit AD in higher-order differentiation
+  <https://github.com/google/jaxopt/pull/143>`_.
+
 Version 0.2
 -----------
 

--- a/tests/bisection_test.py
+++ b/tests/bisection_test.py
@@ -93,5 +93,21 @@ class BisectionTest(jtu.JaxTestCase):
                        lower=lower, upper=lower)
     self.assertRaises(ValueError, bisect.run, None, x, s)
 
+  def test_grad_of_value_and_grad(self):
+    # See https://github.com/google/jaxopt/issues/141
+
+    bisect = lambda x: _projection_simplex_bisect(x)[0]
+
+    def bisect_val(x):
+      val, _ = jax.value_and_grad(bisect)(x)
+      return val
+
+    rng = onp.random.RandomState(0)
+    x = jnp.array(rng.randn(5).astype(onp.float32))
+    g1 = jax.grad(bisect)(x)
+    g2 = jax.grad(bisect_val)(x)
+    self.assertArraysAllClose(g1, g2)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
When a solver is sent through `custom_root`, we customize its derivative (via `jax.custom_vjp`) to make use of the implicit AD machinery. This change customizes all higher-order derivatives similarly.

Fixes #141 and adds a test for it.