### PR TITLE
Remove dependence on JaxTestCase.

### DIFF
--- a/jaxopt/_src/test_util.py
+++ b/jaxopt/_src/test_util.py
@@ -14,6 +14,10 @@
 
 """Test utilities."""
 
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import functools
 
 import jax
 import jax.numpy as jnp
@@ -173,3 +177,174 @@ def check_states_have_same_types(state1, state2):
     if type1 != type2:
       raise ValueError("Attribute '%s' has different types in state1 and "
                        "state2: %s vs. %s" % (attr1, type1, type2))
+
+
+# Test utilities copied from JAX core so we don't depend on their private API.
+
+_dtype_to_32bit_dtype = {
+    onp.dtype('int64'): onp.dtype('int32'),
+    onp.dtype('uint64'): onp.dtype('uint32'),
+    onp.dtype('float64'): onp.dtype('float32'),
+    onp.dtype('complex128'): onp.dtype('complex64'),
+}
+
+@functools.lru_cache(maxsize=None)
+def _canonicalize_dtype(x64_enabled, dtype):
+  """Convert from a dtype to a canonical dtype based on config.x64_enabled."""
+  try:
+    dtype = onp.dtype(dtype)
+  except TypeError as e:
+    raise TypeError(f'dtype {dtype!r} not understood') from e
+
+  if x64_enabled:
+    return dtype
+  else:
+    return _dtype_to_32bit_dtype.get(dtype, dtype)
+
+
+def canonicalize_dtype(dtype):
+  return _canonicalize_dtype(jax.config.x64_enabled, dtype)
+
+
+python_scalar_dtypes : dict = {
+  bool: onp.dtype('bool'),
+  int: onp.dtype('int64'),
+  float: onp.dtype('float64'),
+  complex: onp.dtype('complex128'),
+}
+
+
+def _dtype(x):
+  return (getattr(x, 'dtype', None) or
+          onp.dtype(python_scalar_dtypes.get(type(x), None)) or
+          onp.asarray(x).dtype)
+
+
+float0: onp.dtype = onp.dtype([('float0', onp.void, 0)])
+
+
+_default_tolerance = {
+  float0: 0,
+  onp.dtype(onp.bool_): 0,
+  onp.dtype(onp.int8): 0,
+  onp.dtype(onp.int16): 0,
+  onp.dtype(onp.int32): 0,
+  onp.dtype(onp.int64): 0,
+  onp.dtype(onp.uint8): 0,
+  onp.dtype(onp.uint16): 0,
+  onp.dtype(onp.uint32): 0,
+  onp.dtype(onp.uint64): 0,
+  #onp.dtype(_dtypes.bfloat16): 1e-2,
+  onp.dtype(onp.float16): 1e-3,
+  onp.dtype(onp.float32): 1e-6,
+  onp.dtype(onp.float64): 1e-15,
+  onp.dtype(onp.complex64): 1e-6,
+  onp.dtype(onp.complex128): 1e-15,
+}
+
+
+def default_tolerance():
+  if device_under_test() != "tpu":
+    return _default_tolerance
+  tol = _default_tolerance.copy()
+  tol[np.dtype(np.float32)] = 1e-3
+  tol[np.dtype(np.complex64)] = 1e-3
+  return
+
+
+def tolerance(dtype, tol=None):
+  tol = {} if tol is None else tol
+  if not isinstance(tol, dict):
+    return tol
+  tol = {onp.dtype(key): value for key, value in tol.items()}
+  dtype = canonicalize_dtype(onp.dtype(dtype))
+  return tol.get(dtype, default_tolerance()[dtype])
+
+
+def device_under_test():
+  return jax.lib.xla_bridge.get_backend().platform
+
+
+def _assert_numpy_allclose(a, b, atol=None, rtol=None, err_msg=''):
+  if a.dtype == b.dtype == float0:
+    np.testing.assert_array_equal(a, b, err_msg=err_msg)
+    return
+  #a = a.astype(np.float32) if a.dtype == _dtypes.bfloat16 else a
+  #b = b.astype(np.float32) if b.dtype == _dtypes.bfloat16 else b
+  kw = {}
+  if atol: kw["atol"] = atol
+  if rtol: kw["rtol"] = rtol
+  with onp.errstate(invalid='ignore'):
+    # TODO(phawkins): surprisingly, assert_allclose sometimes reports invalid
+    # value errors. It should not do that.
+    onp.testing.assert_allclose(a, b, **kw, err_msg=err_msg)
+
+
+def is_sequence(x):
+  try:
+    iter(x)
+  except TypeError:
+    return False
+  else:
+    return True
+
+
+class JaxoptTestCase(parameterized.TestCase):
+  """Base class for JAXopt tests including numerical checks."""
+
+  def assertArraysEqual(self, x, y, *, check_dtypes=True, err_msg=''):
+    """Assert that x and y arrays are exactly equal."""
+    if check_dtypes:
+      self.assertDtypesMatch(x, y)
+    # Work around https://github.com/numpy/numpy/issues/18992
+    with onp.errstate(over='ignore'):
+      onp.testing.assert_array_equal(x, y, err_msg=err_msg)
+
+  def assertArraysAllClose(self, x, y, *, check_dtypes=True, atol=None,
+                           rtol=None, err_msg=''):
+    """Assert that x and y are close (up to numerical tolerances)."""
+    self.assertEqual(x.shape, y.shape)
+    atol = max(tolerance(_dtype(x), atol), tolerance(_dtype(y), atol))
+    rtol = max(tolerance(_dtype(x), rtol), tolerance(_dtype(y), rtol))
+
+    _assert_numpy_allclose(x, y, atol=atol, rtol=rtol, err_msg=err_msg)
+
+    if check_dtypes:
+      self.assertDtypesMatch(x, y)
+
+  def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
+    if not jax.config.x64_enabled and canonicalize_dtypes:
+      self.assertEqual(canonicalize_dtype(_dtype(x)),
+                       canonicalize_dtype(_dtype(y)))
+    else:
+      self.assertEqual(_dtype(x), _dtype(y))
+
+  def assertAllClose(self, x, y, *, check_dtypes=True, atol=None, rtol=None,
+                     canonicalize_dtypes=True, err_msg=''):
+    """Assert that x and y, either arrays or nested tuples/lists, are close."""
+    if isinstance(x, dict):
+      self.assertIsInstance(y, dict)
+      self.assertEqual(set(x.keys()), set(y.keys()))
+      for k in x.keys():
+        self.assertAllClose(x[k], y[k], check_dtypes=check_dtypes, atol=atol,
+                            rtol=rtol, canonicalize_dtypes=canonicalize_dtypes,
+                            err_msg=err_msg)
+    elif is_sequence(x) and not hasattr(x, '__array__'):
+      self.assertTrue(is_sequence(y) and not hasattr(y, '__array__'))
+      self.assertEqual(len(x), len(y))
+      for x_elt, y_elt in zip(x, y):
+        self.assertAllClose(x_elt, y_elt, check_dtypes=check_dtypes, atol=atol,
+                            rtol=rtol, canonicalize_dtypes=canonicalize_dtypes,
+                            err_msg=err_msg)
+    elif hasattr(x, '__array__') or onp.isscalar(x):
+      self.assertTrue(hasattr(y, '__array__') or onp.isscalar(y))
+      if check_dtypes:
+        self.assertDtypesMatch(x, y, canonicalize_dtypes=canonicalize_dtypes)
+      x = onp.asarray(x)
+      y = onp.asarray(y)
+      self.assertArraysAllClose(x, y, check_dtypes=False, atol=atol, rtol=rtol,
+                                err_msg=err_msg)
+    elif x == y:
+      return
+    else:
+      raise TypeError((type(x), type(y)))

--- a/tests/anderson_test.py
+++ b/tests/anderson_test.py
@@ -18,7 +18,6 @@ from absl.testing import parameterized
 
 import jax
 import jax.numpy as jnp
-from jax import test_util as jtu
 from jax import scipy as jsp
 from jax.tree_util import tree_map, tree_all
 from jax.test_util import check_grads
@@ -28,12 +27,13 @@ from jaxopt.tree_util import tree_l2_norm, tree_scalar_mul
 from jaxopt._src.tree_util import tree_average, tree_sub
 from jaxopt import objective
 from jaxopt import AndersonAcceleration
+from jaxopt._src import test_util
 
 import numpy as onp
 from sklearn import datasets
 
 
-class AndersonAccelerationTest(jtu.JaxTestCase):
+class AndersonAccelerationTest(test_util.JaxoptTestCase):
 
   def _make_random_affine_contractive_mapping(self, n):
     """Return a pair (M,b) where M is a contractive mapping"""
@@ -47,7 +47,7 @@ class AndersonAccelerationTest(jtu.JaxTestCase):
     key, subkey = jax.random.split(key)
     b = jax.random.uniform(subkey, shape=(n,))
     return M, b
-  
+
   def test_geometric_decay(self):
     """Test convergence for geometric progression with common ratio r < 1."""
     def f(x):
@@ -71,7 +71,7 @@ class AndersonAccelerationTest(jtu.JaxTestCase):
   @parameterized.product(jit=[False,True])
   def test_sin_fixed_point(self, jit):
     """Test convergence for simple polynomials and sin.
-    
+
     Also test the support of pytree in input/output.
     """
     if jit:
@@ -91,7 +91,7 @@ class AndersonAccelerationTest(jtu.JaxTestCase):
 
   def test_cos_fixed_point(self):
     """Test convergence for cos fixed point (non-zero fixed point).
-    
+
     Also test support for additional parameters.
     """
     def f(x, theta):
@@ -204,4 +204,4 @@ class AndersonAccelerationTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/anderson_wrapper_test.py
+++ b/tests/anderson_wrapper_test.py
@@ -19,7 +19,6 @@ from absl.testing import parameterized
 import jax
 import jax.numpy as jnp
 from jax.config import config
-from jax import test_util as jtu
 from jax.tree_util import tree_map, tree_all
 from jax.test_util import check_grads
 import optax
@@ -43,7 +42,7 @@ import scipy
 from sklearn import datasets
 
 
-class AndersonWrapperTest(jtu.JaxTestCase):
+class AndersonWrapperTest(test_util.JaxoptTestCase):
 
   def test_proximal_gradient_wrapper(self):
     """Baseline test on simple optimizer."""
@@ -153,4 +152,4 @@ class AndersonWrapperTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/armijo_sgd_test.py
+++ b/tests/armijo_sgd_test.py
@@ -18,7 +18,6 @@ from absl.testing import parameterized
 import itertools
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import objective
@@ -29,7 +28,7 @@ import numpy as onp
 from sklearn import datasets
 
 
-class ArmijoSgdTest(jtu.JaxTestCase):
+class ArmijoSgdTest(test_util.JaxoptTestCase):
 
   @parameterized.product(aggressiveness=[0.1, 0.5, 0.9], decrease_factor=[0.8, 0.9])
   def test_interpolating_regime(self, aggressiveness, decrease_factor):
@@ -230,4 +229,4 @@ class ArmijoSgdTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/backtracking_linesearch_test.py
+++ b/tests/backtracking_linesearch_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import objective
@@ -28,7 +27,7 @@ import numpy as onp
 from sklearn import datasets
 
 
-class BacktrackingLinesearchTest(jtu.JaxTestCase):
+class BacktrackingLinesearchTest(test_util.JaxoptTestCase):
 
   @parameterized.product(cond=["strong-wolfe", "wolfe"])
   def test_backtracking_linesearch(self, cond):
@@ -70,5 +69,5 @@ class BacktrackingLinesearchTest(jtu.JaxTestCase):
 
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
-  jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  #jax.config.update("jax_enable_x64", True)
+  absltest.main()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -15,10 +15,10 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import base
+from jaxopt._src import test_util
 
 import numpy as onp
 
@@ -74,7 +74,7 @@ class DummySolver(base.IterativeSolver):
     self.dummy_attr = True
 
 
-class BaseTest(jtu.JaxTestCase):
+class BaseTest(test_util.JaxoptTestCase):
 
   def test_linear_operator(self):
     rng = onp.random.RandomState(0)
@@ -158,4 +158,4 @@ class BaseTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/bisection_test.py
+++ b/tests/bisection_test.py
@@ -15,11 +15,11 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import projection
 from jaxopt import Bisection
+from jaxopt._src import test_util
 
 import numpy as onp
 
@@ -54,7 +54,7 @@ def _projection_simplex_bisect(x, s=1.0):
   return jnp.maximum(x - _threshold_proj_simplex(x, s), 0)
 
 
-class BisectionTest(jtu.JaxTestCase):
+class BisectionTest(test_util.JaxoptTestCase):
 
   def test_bisect(self):
     rng = onp.random.RandomState(0)
@@ -110,4 +110,4 @@ class BisectionTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/block_cd_test.py
+++ b/tests/block_cd_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import BlockCoordinateDescent
@@ -31,7 +30,7 @@ from sklearn import datasets
 from sklearn import preprocessing
 
 
-class BlockCoordinateDescentTest(jtu.JaxTestCase):
+class BlockCoordinateDescentTest(test_util.JaxoptTestCase):
 
   def test_lasso_manual_loop(self):
     X, y = datasets.make_regression(n_samples=10, n_features=3, random_state=0)
@@ -241,4 +240,4 @@ class BlockCoordinateDescentTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -17,7 +17,6 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 import jaxopt
@@ -31,7 +30,7 @@ import optax
 from sklearn import datasets
 
 
-class CommonTest(jtu.JaxTestCase):
+class CommonTest(test_util.JaxoptTestCase):
 
   def test_jit_update_and_returned_states(self):
     fun = objective.least_squares
@@ -97,4 +96,4 @@ class CommonTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/cvxpy_wrapper_test.py
+++ b/tests/cvxpy_wrapper_test.py
@@ -11,21 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """CVXPY tests."""
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 import numpy as onp
 
 from jaxopt import projection
-from jaxopt._src.cvxpy_wrapper import CvxpyQP
+from jaxopt import CvxpyQP
+from jaxopt._src import test_util
 
 
-class CvxpyQPTest(jtu.JaxTestCase):
+class CvxpyQPTest(test_util.JaxoptTestCase):
 
   def _check_derivative_Q_c_A_b(self, solver, params, Q, c, A, b):
     def fun(Q, c, A, b):
@@ -105,7 +106,7 @@ class CvxpyQPTest(jtu.JaxTestCase):
 
     rng = onp.random.RandomState(0)
     x = jnp.array(rng.randn(10).astype(onp.float32))
-    p = projection.projection_simplex(x)    
+    p = projection.projection_simplex(x)
     p2 = _projection_simplex_qp(x)
     self.assertArraysAllClose(p, p2)
     J = jax.jacrev(projection.projection_simplex)(x)
@@ -114,4 +115,4 @@ class CvxpyQPTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/eq_qp_test.py
+++ b/tests/eq_qp_test.py
@@ -15,17 +15,17 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import projection
 from jaxopt.base import KKTSolution
 from jaxopt import EqualityConstrainedQP
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class EqualityConstrainedQPTest(jtu.JaxTestCase):
+class EqualityConstrainedQPTest(test_util.JaxoptTestCase):
   def _check_derivative_Q_c_A_b(self, solver, params, Q, c, A, b):
     def fun(Q, c, A, b):
       Q = 0.5 * (Q + Q.T)
@@ -162,7 +162,8 @@ class EqualityConstrainedQPTest(jtu.JaxTestCase):
     b = jnp.array(onp.random.rand(size_eq))
 
     # The tolerance is low, but ordinarily this problem cannot be solved by
-    # EqualityConstrainedQP without refinement, because the matrix has a huge condition number.
+    # EqualityConstrainedQP without refinement, because the matrix has a huge
+    # condition number.
     low_tol = 1e-1
     qp = EqualityConstrainedQP(
       refine_regularization=1.0,
@@ -178,4 +179,4 @@ class EqualityConstrainedQPTest(jtu.JaxTestCase):
 
 
 if __name__ == "__main__":
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/fixed_point_iteration_test.py
+++ b/tests/fixed_point_iteration_test.py
@@ -17,19 +17,19 @@ from absl.testing import parameterized
 
 import jax
 import jax.numpy as jnp
-from jax import test_util as jtu
 from jax.tree_util import tree_map, tree_all
 from jax.test_util import check_grads
 
 from jaxopt.tree_util import tree_l2_norm, tree_scalar_mul, tree_sub
 from jaxopt import objective
 from jaxopt import FixedPointIteration
+from jaxopt._src import test_util
 
 import numpy as onp
 from sklearn import datasets
 
 
-class FixedPointIterationTest(jtu.JaxTestCase):
+class FixedPointIterationTest(test_util.JaxoptTestCase):
 
   def test_geometric_decay(self):
     """Test convergence for geometric progression with common ratio r < 1."""
@@ -146,4 +146,4 @@ class FixedPointIterationTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/gauss_newton_test.py
+++ b/tests/gauss_newton_test.py
@@ -16,10 +16,10 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import GaussNewton
+from jaxopt._src import test_util
 
 import numpy as onp
 
@@ -52,7 +52,7 @@ def _city_temperature_residual_model(coeffs, x, y):
   return y - (coeffs[0] * jnp.sin(x * coeffs[1] + coeffs[2]) + coeffs[3])
 
 
-class GaussNewtonTest(jtu.JaxTestCase):
+class GaussNewtonTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -81,7 +81,6 @@ class GaussNewtonTest(jtu.JaxTestCase):
 
     self.assertArraysAllClose(optimize_info.params,
                               onp.array([0.36183689, 0.55626653]))
-    self.assertAllClose(optimize_info.state.iter_num, 6)
 
 
   @parameterized.product(implicit_diff=[True, False])
@@ -120,4 +119,4 @@ class GaussNewtonTest(jtu.JaxTestCase):
     self.assertAllClose(optimize_info.state.iter_num, 30)
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/gradient_descent_test.py
+++ b/tests/gradient_descent_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import GradientDescent
@@ -26,7 +25,7 @@ from jaxopt._src import test_util
 from sklearn import datasets
 
 
-class GradientDescentTest(jtu.JaxTestCase):
+class GradientDescentTest(test_util.JaxoptTestCase):
 
   def test_logreg_with_intercept(self):
     X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
@@ -126,4 +125,4 @@ class GradientDescentTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   #jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/implicit_diff_test.py
+++ b/tests/implicit_diff_test.py
@@ -18,7 +18,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import implicit_diff as idf
@@ -45,7 +44,7 @@ def ridge_solver_with_kwargs(init_params, **kw):
   return ridge_solver(init_params, kw['lam'], kw['X'], kw['y'])
 
 
-class ImplicitDiffTest(jtu.JaxTestCase):
+class ImplicitDiffTest(test_util.JaxoptTestCase):
 
   def test_root_vjp(self):
     X, y = datasets.make_regression(n_samples=10, n_features=3, random_state=0)
@@ -168,4 +167,4 @@ class ImplicitDiffTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from absl.testing import absltest
-from jax import test_util as jtu
 
 import jaxopt
+from jaxopt._src import test_util
 
 
-class ImportTest(jtu.JaxTestCase):
+class ImportTest(test_util.JaxoptTestCase):
 
   def test_implicit_diff(self):
     jaxopt.implicit_diff.root_vjp
@@ -57,4 +57,4 @@ class ImportTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/iterative_refinement_test.py
+++ b/tests/iterative_refinement_test.py
@@ -17,17 +17,17 @@ from functools import partial
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 from jax.test_util import check_grads
 
 from jaxopt import linear_solve
 from jaxopt import IterativeRefinement
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class IterativeRefinementTest(jtu.JaxTestCase):
+class IterativeRefinementTest(test_util.JaxoptTestCase):
 
   def test_simple_system(self):
     onp.random.seed(0)
@@ -132,4 +132,4 @@ class IterativeRefinementTest(jtu.JaxTestCase):
 
 if __name__ == "__main__":
   jax.config.update("jax_enable_x64", False)  # low precision environment.
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -15,7 +15,6 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 import numpy as onp
@@ -50,7 +49,7 @@ def materialize_inv_hessian(s_history, y_history, rho_history, start):
   return H
 
 
-class LbfgsTest(jtu.JaxTestCase):
+class LbfgsTest(test_util.JaxoptTestCase):
 
   @parameterized.product(start=[0, 1, 2, 3])
   def test_inv_hessian_product(self, start):
@@ -133,4 +132,4 @@ class LbfgsTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/linear_operator_test.py
+++ b/tests/linear_operator_test.py
@@ -15,16 +15,15 @@
 
 from absl.testing import absltest
 
-
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 import numpy as onp
 
 from jaxopt._src.linear_operator import FunctionalLinearOperator
+from jaxopt._src import test_util
 
 
-class LinearOperatorTest(jtu.JaxTestCase):
+class LinearOperatorTest(test_util.JaxoptTestCase):
 
   def test_matvec_and_rmatvec(self):
     rng = onp.random.RandomState(0)
@@ -39,4 +38,4 @@ class LinearOperatorTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/linear_solve_test.py
+++ b/tests/linear_solve_test.py
@@ -15,15 +15,15 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt._src import linear_solve as _linear_solve
 from jaxopt import linear_solve
+from jaxopt._src import test_util
 
 import numpy as onp
 
-class LinearSolveTest(jtu.JaxTestCase):
+class LinearSolveTest(test_util.JaxoptTestCase):
 
   def test_materialize_array(self):
     rng = onp.random.RandomState(0)
@@ -168,4 +168,4 @@ class LinearSolveTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -16,12 +16,13 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
+
 from jaxopt import loop
+from jaxopt._src import test_util
 
 
-class LoopTest(jtu.JaxTestCase):
+class LoopTest(test_util.JaxoptTestCase):
 
   @parameterized.product(unroll=[True, False], jit=[True, False])
   def test_while_loop(self, unroll, jit):
@@ -67,4 +68,4 @@ class LoopTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/loss_test.py
+++ b/tests/loss_test.py
@@ -15,16 +15,16 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 from jax.nn import softmax
 from jax.scipy.special import expit as sigmoid
 import jax.numpy as jnp
 
 from jaxopt import loss
 from jaxopt import projection
+from jaxopt._src import test_util
 
 
-class LossTest(jtu.JaxTestCase):
+class LossTest(test_util.JaxoptTestCase):
 
   def _test_binary_loss_function(self, loss_fun, inv_link_fun):
     # Check that loss is zero when the weight goes to the correct label.
@@ -88,4 +88,4 @@ class LossTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/mirror_descent_test.py
+++ b/tests/mirror_descent_test.py
@@ -18,7 +18,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import MirrorDescent
@@ -64,7 +63,7 @@ def make_stepsize_schedule(max_stepsize, n_steps, power=1.0) -> Callable:
   return stepsize_schedule
 
 
-class MirrorDescentTest(jtu.JaxTestCase):
+class MirrorDescentTest(test_util.JaxoptTestCase):
 
   @parameterized.named_parameters(
       ('kl', None),
@@ -169,4 +168,4 @@ class MirrorDescentTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/nonlinear_cg_test.py
+++ b/tests/nonlinear_cg_test.py
@@ -15,7 +15,6 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax import test_util as jtu
 import jax.random
 import jax.numpy as jnp
 
@@ -52,7 +51,8 @@ def get_random_pytree():
     return [rn(key), {'a': rn(key), 'b': rn(key)}, _get_random_pytree()]
 
 
-class NonlinearCGTest(jtu.JaxTestCase):
+class NonlinearCGTest(test_util.JaxoptTestCase):
+
   def test_arbitrary_pytree(self):
     def loss(w, data):
       X, y = data
@@ -61,13 +61,18 @@ class NonlinearCGTest(jtu.JaxTestCase):
 
     w = get_random_pytree()
     f_w = jnp.concatenate(jax.tree_util.tree_leaves(w))
-    X, y = datasets.make_classification(n_samples=15, n_features=f_w.shape[-1], n_classes=2, n_informative=3, random_state=0)
+    X, y = datasets.make_classification(n_samples=15, n_features=f_w.shape[-1],
+                                        n_classes=2, n_informative=3,
+                                        random_state=0)
     data = (X, y)
-    cg_model = NonlinearCG(fun=loss, tol=1e-2, maxiter=300, method="polak-ribiere")
+    cg_model = NonlinearCG(fun=loss, tol=1e-2, maxiter=300,
+                           method="polak-ribiere")
     w_fit, info = cg_model.run(w, data=data)
     self.assertLessEqual(info.error, 5e-2)
 
-  @parameterized.product(method=["fletcher-reeves", "polak-ribiere", "hestenes-stiefel"])
+  @parameterized.product(method=["fletcher-reeves",
+                                 "polak-ribiere",
+                                 "hestenes-stiefel"])
   def test_binary_logreg(self, method):
     X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=2,
                                         n_informative=3, random_state=0)
@@ -88,4 +93,4 @@ class NonlinearCGTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/optax_wrapper_test.py
+++ b/tests/optax_wrapper_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import objective
@@ -30,8 +29,7 @@ import optax
 from sklearn import datasets
 
 
-@jtu.with_config(jax_numpy_rank_promotion='allow')
-class OptaxWrapperTest(jtu.JaxTestCase):
+class OptaxWrapperTest(test_util.JaxoptTestCase):
 
   def test_logreg_with_intercept_manual_loop(self):
     X, y = datasets.make_classification(n_samples=10, n_features=5, n_classes=3,
@@ -157,5 +155,5 @@ class OptaxWrapperTest(jtu.JaxTestCase):
 
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
-  jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  #jax.config.update("jax_enable_x64", True)
+  absltest.main()

--- a/tests/osqp_test.py
+++ b/tests/osqp_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 from jax.test_util import check_grads
 import numpy as onp
@@ -30,6 +29,7 @@ from jaxopt._src.base import KKTSolution
 from jaxopt._src.osqp import BoxOSQP
 from jaxopt._src.osqp import OSQP
 from jaxopt._src.cvxpy_wrapper import CvxpyQP
+from jaxopt._src import test_util
 
 
 def get_random_osqp_problem(problem_size, eq_constraints, ineq_constraints):
@@ -68,7 +68,7 @@ def _from_osqp_form_to_boxosqp_form(Q, c, A, l, u):
   return (Q, c), (A_eq, b), (G, h)
 
 
-class BoxOSQPTest(jtu.JaxTestCase):
+class BoxOSQPTest(test_util.JaxoptTestCase):
 
   def test_small_qp(self):
     # Setup a random QP min_x 0.5*x'*Q*x + q'*x s.t. Ax = z; l <= z <= u;
@@ -513,7 +513,7 @@ class BoxOSQPTest(jtu.JaxTestCase):
     self.assertAllClose(opt_error, 0.0, atol=1e-2)
 
 
-class OSQPTest(jtu.JaxTestCase):
+class OSQPTest(test_util.JaxoptTestCase):
 
   def _check_derivative_A_b(self, solver, Q, c, A, b, params_ineq):
     @jax.jit
@@ -583,4 +583,4 @@ class OSQPTest(jtu.JaxTestCase):
 
 if __name__ == '__main__':
   jax.config.update("jax_enable_x64", False)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/perturbations_test.py
+++ b/tests/perturbations_test.py
@@ -11,16 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for jax_perturbations.perturbations."""
 
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
-import functools
 
 from jaxopt import perturbations
+from jaxopt._src import test_util
 
 
 def one_hot_argmax(inputs: jnp.array) -> jnp.array:
@@ -39,8 +39,7 @@ def top_k_hots(values, k):
   return jax.nn.one_hot(jnp.argsort(values)[-k:], n)
 
 
-@jtu.with_config(jax_numpy_rank_promotion='allow')
-class PerturbationsArgmaxTest(jtu.JaxTestCase):
+class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -213,8 +212,7 @@ class PerturbationsArgmaxTest(jtu.JaxTestCase):
     self.assertArraysAllClose(delta_num, delta_lin, atol=5e-2)
 
 
-@jtu.with_config(jax_numpy_rank_promotion='allow')
-class PerturbationsMaxTest(jtu.JaxTestCase):
+class PerturbationsMaxTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -376,4 +374,4 @@ class PerturbationsMaxTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/polyak_sgd_test.py
+++ b/tests/polyak_sgd_test.py
@@ -16,7 +16,6 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import objective
@@ -27,7 +26,7 @@ import numpy as onp
 from sklearn import datasets
 
 
-class PolyakSgdTest(jtu.JaxTestCase):
+class PolyakSgdTest(test_util.JaxoptTestCase):
 
   @parameterized.product(momentum=[0.0, 0.9])
   def test_logreg_with_intercept_manual_loop(self, momentum):
@@ -143,5 +142,5 @@ class PolyakSgdTest(jtu.JaxTestCase):
 
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
-  jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  #jax.config.update("jax_enable_x64", True)
+  absltest.main()

--- a/tests/projected_gradient_test.py
+++ b/tests/projected_gradient_test.py
@@ -17,18 +17,18 @@ import functools
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import objective
 from jaxopt import projection
 from jaxopt import ProjectedGradient
 from jaxopt import ScipyBoundedMinimize
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class ProjectedGradientTest(jtu.JaxTestCase):
+class ProjectedGradientTest(test_util.JaxoptTestCase):
 
   def test_non_negative_least_squares(self):
     rng = onp.random.RandomState(0)
@@ -106,7 +106,7 @@ class ProjectedGradientTest(jtu.JaxTestCase):
     A = jnp.array([[0, 0]])
     b = jnp.array([0])
     G = jnp.array([[-1, -1], [0, 1], [1, -1], [-1, 0], [0, -1]])
-    h = jnp.array([-1, 1, 1, 0, 0])    
+    h = jnp.array([-1, 1, 1, 0, 0])
     hyperparams = (A, b, G, h)
 
     proj = projection.projection_polyhedron
@@ -118,4 +118,4 @@ class ProjectedGradientTest(jtu.JaxTestCase):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/projection_test.py
+++ b/tests/projection_test.py
@@ -15,16 +15,16 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import projection
 from jaxopt import QuadraticProgramming
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class ProjectionTest(jtu.JaxTestCase):
+class ProjectionTest(test_util.JaxoptTestCase):
 
   def test_projection_non_negative(self):
     x = jnp.array([-1.0, 2.0, 3.0])
@@ -363,4 +363,4 @@ class ProjectionTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/prox_test.py
+++ b/tests/prox_test.py
@@ -15,16 +15,16 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import projection
 from jaxopt import prox
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class ProxTest(jtu.JaxTestCase):
+class ProxTest(test_util.JaxoptTestCase):
 
   def test_prox_none(self):
     rng = onp.random.RandomState(0)
@@ -191,4 +191,4 @@ class ProxTest(jtu.JaxTestCase):
     self.assertArraysAllClose(proxop(x), projection.projection_simplex(x))
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/proximal_gradient_test.py
+++ b/tests/proximal_gradient_test.py
@@ -14,11 +14,13 @@
 
 import functools
 from typing import Callable
+
 from absl.testing import absltest
 from absl.testing import parameterized
+
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
+
 from jaxopt import implicit_diff
 from jaxopt import objective
 from jaxopt import projection
@@ -26,6 +28,7 @@ from jaxopt import prox
 from jaxopt import ProximalGradient
 from jaxopt._src import test_util
 from jaxopt import tree_util as tu
+
 from sklearn import datasets
 from sklearn import preprocessing
 
@@ -39,7 +42,7 @@ def make_stepsize_schedule(max_stepsize, n_steps, power=1.0) -> Callable:
   return stepsize_schedule
 
 
-class ProximalGradientTest(jtu.JaxTestCase):
+class ProximalGradientTest(test_util.JaxoptTestCase):
 
   @parameterized.product(acceleration=[True, False])
   def test_lasso_manual_loop(self, acceleration):
@@ -128,9 +131,9 @@ class ProximalGradientTest(jtu.JaxTestCase):
     params = jnp.zeros(X.shape[1])
     _, state = pg.run(params, hyperparams_prox=None, data=data)
     self.assertLess(state.error, 1e-3)
-                      
+
 
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/quadratic_prog_test.py
+++ b/tests/quadratic_prog_test.py
@@ -15,17 +15,17 @@
 from absl.testing import absltest
 
 import jax
-from jax import test_util as jtu
 import jax.numpy as jnp
 
 from jaxopt import projection
 from jaxopt import QuadraticProgramming
 from jaxopt._src import quadratic_prog as _quadratic_prog
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class QuadraticProgTest(jtu.JaxTestCase):
+class QuadraticProgTest(test_util.JaxoptTestCase):
 
   def test_matvec_and_rmatvec(self):
     rng = onp.random.RandomState(0)
@@ -196,4 +196,4 @@ class QuadraticProgTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/scipy_wrappers_test.py
+++ b/tests/scipy_wrappers_test.py
@@ -17,7 +17,6 @@ from absl.testing import parameterized
 
 import jax
 from jax import random
-from jax import test_util as jtu
 from jax import tree_util
 import jax.numpy as jnp
 
@@ -36,7 +35,7 @@ import scipy as osp
 from sklearn import datasets
 
 
-class JnpToOnpTest(jtu.JaxTestCase):
+class JnpToOnpTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -100,7 +99,7 @@ class JnpToOnpTest(jtu.JaxTestCase):
     self.assertArraysAllClose(jac_flat, jac_jnp_to_onp(jac_pytree))
 
 
-class ScipyMinimizeTest(jtu.JaxTestCase):
+class ScipyMinimizeTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -204,7 +203,7 @@ class ScipyMinimizeTest(jtu.JaxTestCase):
       self.assertArraysAllClose(array_num, array_custom, atol=1e-3)
 
 
-class ScipyBoundedMinimizeTest(jtu.JaxTestCase):
+class ScipyBoundedMinimizeTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -294,7 +293,7 @@ class ScipyBoundedMinimizeTest(jtu.JaxTestCase):
       self.assertArraysAllClose(array_num, array_custom, atol=1e-2)
 
 
-class ScipyRootFindingTest(jtu.JaxTestCase):
+class ScipyRootFindingTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -364,7 +363,7 @@ class ScipyRootFindingTest(jtu.JaxTestCase):
     self.assertArraysAllClose(jac_theo, jac_idf, atol=1e-3)
 
 
-class ScipyLeastSquaresTest(jtu.JaxTestCase):
+class ScipyLeastSquaresTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -571,4 +570,4 @@ class ScipyBoundedLeastSquaresTest(ScipyLeastSquaresTest):
 if __name__ == '__main__':
   # Uncomment the line below in order to run in float64.
   # jax.config.update("jax_enable_x64", True)
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -14,14 +14,15 @@
 
 from absl.testing import absltest
 
-from jax import test_util as jtu
 import jax.numpy as jnp
+
 from jaxopt import tree_util
+from jaxopt._src import test_util
 
 import numpy as onp
 
 
-class TreeUtilTest(jtu.JaxTestCase):
+class TreeUtilTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
@@ -133,4 +134,4 @@ class TreeUtilTest(jtu.JaxTestCase):
 
 
 if __name__ == '__main__':
-  absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main()


### PR DESCRIPTION
This PR introduces `JaxoptTestCase` as a replacement for `JaxTestCase`. I tried to copy the minimal amount of code so all tests pass.