### PR TITLE
Remove QuadraticProg in projections

### DIFF
--- a/tests/fixed_point_iteration_test.py
+++ b/tests/fixed_point_iteration_test.py
@@ -102,7 +102,7 @@ class FixedPointIterationTest(test_util.JaxoptTestCase):
     fp = FixedPointIteration(f, maxiter=4*1000, tol=1e-6, implicit_diff=implicit_diff)
     def solve_run(args, kwargs):
       return fp.run(x0, *args, **kwargs)[0]
-    check_grads(solve_run, args=([theta], {}), order=1, modes=['rev'], eps=None)
+    check_grads(solve_run, args=([theta], {}), order=1, modes=['rev'], eps=1e-3)
 
   def test_grads_flat_landscape(self):
     """Test correctness of gradients."""

--- a/tests/projection_test.py
+++ b/tests/projection_test.py
@@ -18,8 +18,8 @@ import jax
 import jax.numpy as jnp
 
 from jaxopt import projection
-from jaxopt import QuadraticProgramming
 from jaxopt._src import test_util
+from jaxopt import OSQP
 
 import numpy as onp
 
@@ -265,7 +265,7 @@ class ProjectionTest(test_util.JaxoptTestCase):
     params = (A, b)
 
     p = projection.projection_affine_set(x, params)
-    self.assertAllClose(jnp.dot(A, p), b)
+    self.assertAllClose(jnp.dot(A, p), b, atol=1e-3, rtol=1e-3)
 
     jac_fun = jax.jacrev(projection.projection_affine_set, argnums=0)
     jac_x = jac_fun(x, params)
@@ -287,7 +287,7 @@ class ProjectionTest(test_util.JaxoptTestCase):
     params = (A, b, G, h)
 
     p = projection.projection_polyhedron(x, params)
-    self.assertAllClose(jnp.dot(A, p), b)
+    self.assertAllClose(jnp.dot(A, p), b, atol=1e-3, rtol=1e-3)
 
     jac_fun = jax.jacrev(projection.projection_polyhedron, argnums=0)
     jac_x = jac_fun(x, params)
@@ -328,9 +328,9 @@ class ProjectionTest(test_util.JaxoptTestCase):
     G = jnp.concatenate((-jnp.eye(len(x)), jnp.eye(len(x))))
     h = jnp.concatenate((alpha, beta))
     hyperparams = dict(params_obj=(Q, -x), params_eq=(A, b), params_ineq=(G, h))
-    qp = QuadraticProgramming()
-    p2 = qp.run(**hyperparams).params[0]
-    self.assertArraysAllClose(p, p2, atol=1e-5)
+    osqp = OSQP()
+    p2 = osqp.run(**hyperparams).params.primal
+    self.assertArraysAllClose(p, p2, atol=1e-3)
 
   def test_projection_box_section_infeasible(self):
     x = jnp.array([1.2, 3.0, 0.7])


### PR DESCRIPTION
## What changed ?

Last steps in the removal of `QuadraticProgramming` class: replacing it by `OSQP` and `EqualityConstrainedQP` in `_src/projections.py`.

By default the function `projection_polyhedron` checks if the polyhedron is empty ([issue encountered by a user](https://github.com/google/jaxopt/issues/70#issuecomment-943701279)). This check is performed by raising an exception. This prevents the code of the projection to be jittable. `OSQP` offers ways to check feasability within `jit` block without raising an exception but by returning an error code in `state.status` instead. This can be left for future work.

## Future work

In future PRs we could wrap projections in classes (instead of functions) to separate differentiable parameters and non differentiable hyper-parameters.