### PR TITLE
fix tree_where for singleton pytrees

### DIFF
--- a/jaxopt/_src/osqp.py
+++ b/jaxopt/_src/osqp.py
@@ -29,11 +29,11 @@ from jax.tree_util import tree_reduce
 
 from jaxopt._src import base
 from jaxopt._src import implicit_diff as idf
-from jaxopt._src.tree_util import tree_add, tree_sub, tree_mul
-from jaxopt._src.tree_util import tree_scalar_mul, tree_add_scalar_mul
-from jaxopt._src.tree_util import tree_map, tree_vdot, tree_dot
-from jaxopt._src.tree_util import tree_ones_like, tree_zeros_like, tree_where
-from jaxopt._src.tree_util import tree_negative, tree_l2_norm, tree_inf_norm
+from jaxopt.tree_util import tree_add, tree_sub, tree_mul
+from jaxopt.tree_util import tree_scalar_mul, tree_add_scalar_mul
+from jaxopt.tree_util import tree_map, tree_vdot
+from jaxopt.tree_util import tree_ones_like, tree_zeros_like, tree_where
+from jaxopt.tree_util import tree_negative, tree_l2_norm, tree_inf_norm
 from jaxopt._src.linear_operator import DenseLinearOperator, _make_linear_operator
 import jaxopt.linear_solve as linear_solve
 from jaxopt.projection import projection_box
@@ -456,10 +456,10 @@ class BoxOSQP(base.IterativeSolver):
     certif_Q   = tree_inf_norm(Q(delta_x))
     certif_c   = tree_vdot(c, delta_x)
 
-    unbouned_l = tree_map(lambda li: li == -jnp.inf, l)
-    unbouned_u = tree_map(lambda ui: ui == jnp.inf, u)
-    certif_l   = tree_map(lambda adxi,li: jnp.all(li <= adxi), Adx, tree_where(unbouned_l, -jnp.inf, -criterion))
-    certif_u   = tree_map(lambda adxi,ui: jnp.all(adxi <= ui), Adx, tree_where(unbouned_u, jnp.inf, criterion))
+    unbounded_l = tree_map(lambda li: li == -jnp.inf, l)
+    unbounded_u = tree_map(lambda ui: ui == jnp.inf, u)
+    certif_l   = tree_map(lambda adxi,li: jnp.all(li <= adxi), Adx, tree_where(unbounded_l, -jnp.inf, -criterion))
+    certif_u   = tree_map(lambda adxi,ui: jnp.all(adxi <= ui), Adx, tree_where(unbounded_u, jnp.inf, criterion))
     certif_A   = tree_reduce(jnp.logical_and, tree_map(jnp.logical_and, certif_l, certif_u))
 
     certif_dual_infeasible = jnp.logical_and(jnp.logical_and(certif_Q <= criterion, certif_c <= criterion), certif_A)

--- a/jaxopt/_src/tree_util.py
+++ b/jaxopt/_src/tree_util.py
@@ -133,17 +133,30 @@ def tree_inf_norm(tree_x):
 
 
 def tree_where(cond, a, b):
-  """jnp.where for trees. Mimic broadcasting semantic of jnp.where."""
-  la = len(tree_leaves(a))
-  lb = len(tree_leaves(b))
-  lc = len(tree_leaves(cond))
-  if la > 1 and lb > 1:
-    return tree_map(lambda c,u,v: jnp.where(c, u, v), cond, a, b)
-  if la > 1 and lb == 1:
-    return tree_map(lambda c,u: jnp.where(c, u, b), cond, a)
-  if la == 1 and lb > 1:
-    return tree_map(lambda c,v: jnp.where(c, a, v), cond, b)
-  return tree_map(lambda c: jnp.where(c, a, b), cond)
+  """jnp.where for trees.
+  
+  Mimic broadcasting semantic of jnp.where.
+  a and b can be arrays (including scalars) broadcastable to the leaves of cond.
+  
+  Args:
+    cond: pytree of booleans arrays.
+    a   : pytree of arrays, or single array broadcastable
+      to the shapes of leaves of cond.
+    b   : pytree of arrays, or single array broadcastable
+      to the shapes of leaves of cond.
+    
+  Returns:
+    pytree of arrays, or single array
+  """
+  a_scalar = tu.treedef_is_leaf(tu.tree_structure(a))
+  b_scalar = tu.treedef_is_leaf(tu.tree_structure(b))
+  if a_scalar and b_scalar:
+    return tree_map(lambda c: jnp.where(c, a, b), cond)
+  if b_scalar:
+    return tree_map(lambda c, u: jnp.where(c, u, b), cond, a)
+  if a_scalar:
+    return tree_map(lambda c, v: jnp.where(c, a, v), cond, b)
+  return tree_map(lambda c, u, v: jnp.where(c, u, v), cond, a, b)
 
 
 def tree_negative(tree):

--- a/jaxopt/tree_util.py
+++ b/jaxopt/tree_util.py
@@ -20,8 +20,13 @@ from jaxopt._src.tree_util import tree_sub
 from jaxopt._src.tree_util import tree_mul
 from jaxopt._src.tree_util import tree_scalar_mul
 from jaxopt._src.tree_util import tree_add_scalar_mul
+from jaxopt._src.tree_util import tree_dot
 from jaxopt._src.tree_util import tree_vdot
 from jaxopt._src.tree_util import tree_div
 from jaxopt._src.tree_util import tree_sum
 from jaxopt._src.tree_util import tree_l2_norm
+from jaxopt._src.tree_util import tree_where
 from jaxopt._src.tree_util import tree_zeros_like
+from jaxopt._src.tree_util import tree_ones_like
+from jaxopt._src.tree_util import tree_negative
+from jaxopt._src.tree_util import tree_inf_norm

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -132,6 +132,20 @@ class TreeUtilTest(test_util.JaxoptTestCase):
     tree = tree_util.tree_zeros_like(self.tree_A)
     self.assertAllClose(tree_util.tree_l2_norm(tree), 0.0)
 
+  def test_tree_where(self):
+    c = jnp.array([True, False, True, False]), jnp.array([True, False, False, True])
+    a = jnp.array([1., 2., 3., 4.]), jnp.array([5., 6., 7., 8.])
+    b = jnp.array(42.), jnp.array(13.)
+    d = tree_util.tree_where(c, a, b)
+    self.assertAllClose(d[0], jnp.array([1., 42., 3., 42.]))
+    self.assertAllClose(d[1], jnp.array([5., 13., 13., 8.]))
+
+    c = [jnp.array([True, False, True, False])]
+    a = [jnp.array([1., 2., 3., 4.])]
+    b = [jnp.array(42.)]
+    d = tree_util.tree_where(c, a, b)
+    self.assertAllClose(d[0], jnp.array([1., 42., 3., 42.]))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fix minor bug on `tree_where` as mentioned [here](https://github.com/google/jaxopt/issues/144).