### PR TITLE
Add support for leaf cond pytrees in `tree_util.tree_where`.

### DIFF
--- a/jaxopt/tree_util.py
+++ b/jaxopt/tree_util.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from jaxopt._src.tree_util import broadcast_pytrees
 from jaxopt._src.tree_util import tree_map
 from jaxopt._src.tree_util import tree_multimap
 from jaxopt._src.tree_util import tree_reduce


### PR DESCRIPTION
Generalizes `tree_util.tree_where` by allowing any of its arguments to be a leaf pytree (i.e. single array), including `cond`. The function `broadcast_pytree` was factored out of `tree_where`, as it could presumably be used in combination with other `tree_x`methods in `tree_util`.