### PR TITLE
convert pytree leaves to jax arrays to determine their shape/dtype

### DIFF
--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -189,8 +189,8 @@ def make_onp_to_jnp(pytree_topology: PyTreeTopology) -> Callable:
 def pytree_topology_from_example(x_jnp: Any) -> PyTreeTopology:
   """Returns a PyTreeTopology encoding the PyTree structure of `x_jnp`."""
   leaves, treedef = tree_util.tree_flatten(x_jnp)
-  shapes = [leaf.shape for leaf in leaves]
-  dtypes = [leaf.dtype for leaf in leaves]
+  shapes = [jnp.asarray(leaf).shape for leaf in leaves]
+  dtypes = [jnp.asarray(leaf).dtype for leaf in leaves]
   return PyTreeTopology(treedef=treedef, shapes=shapes, dtypes=dtypes)
 
 

--- a/tests/scipy_wrappers_test.py
+++ b/tests/scipy_wrappers_test.py
@@ -202,6 +202,13 @@ class ScipyMinimizeTest(test_util.JaxoptTestCase):
                                        tree_util.tree_leaves(jac_custom)):
       self.assertArraysAllClose(array_num, array_custom, atol=1e-3)
 
+  def test_issue_201(self):
+    # https://github.com/google/jaxopt/issues/201
+    def loss(params): return params ** 2
+    params = 0.0
+    out = ScipyMinimize(fun=loss).run(params)  # doesn't crash
+    self.assertArraysEqual(out.params, jnp.array(0.))
+
 
 class ScipyBoundedMinimizeTest(test_util.JaxoptTestCase):
 


### PR DESCRIPTION
fixes #201 

We were essentially asserting that leaves are arrays by trying to read their `shape` and `dtype` attributes. I could imagine wanting to avoid `jnp` conversion (including device placement of scalar leaves). But those may be edge cases; worthwhile to at least handle them correctly for now.