### PR TITLE
feat: add Python 3.10 support officially

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="optimization, root finding, implicit differentiation, jax",
     requires_python=">=3.7",


### PR DESCRIPTION
This officially adds Python 3.10 support.

I have used `jaxopt` with Python 3.10 without encountering any issues so far, so I expect that simply adding the classifier is the only change needed.

Python 3.10 is also added to CI testing. Let me know if there is something I have missed.

Fix #213 