### PR TITLE
Convenience API for OSQP

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+Development version
+___________________
+
+Bug fixes and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Add support for quadratic polynomial `fun` in :class:`jaxopt.BoxOSQP` and :class:`jaxopt.OSQP`.
+
+Contributors
+~~~~~~~~~~~~
+
+Louis Béthune.
+
 Version 0.4.2
 -------------
 
@@ -82,7 +95,7 @@ Bug fixes and enhancements
 Contributors
 ~~~~~~~~~~~~
 
-Felipe Llinares, Fabian Pedregosa, Ian Williamson, Louis Bétune, Mathieu Blondel, Roy Frostig.
+Felipe Llinares, Fabian Pedregosa, Ian Williamson, Louis Béthune, Mathieu Blondel, Roy Frostig.
 
 Version 0.3
 -----------
@@ -145,7 +158,7 @@ Deprecations
 Contributors
 ~~~~~~~~~~~~
 
-Fabian Pedregosa, Felipe Llinares, Geoffrey Negiar, Louis Bethune, Mathieu
+Fabian Pedregosa, Felipe Llinares, Geoffrey Negiar, Louis Béthune, Mathieu
 Blondel, Vikas Sindhwani.
 
 Version 0.1.1

--- a/docs/quadratic_programming.rst
+++ b/docs/quadratic_programming.rst
@@ -16,6 +16,7 @@ The best choice will depend on the usage.
    * - Name
      - jit
      - matvec
+     - fun
      - precision
      - stability
      - speed
@@ -23,11 +24,13 @@ The best choice will depend on the usage.
    * - :class:`jaxopt.EqualityConstrainedQP`
      - yes
      - yes
+     - no
      - ++
      - \+
      - +++
      - (Q, c), (A, b)
    * - :class:`jaxopt.CvxpyQP`
+     - no
      - no
      - no
      - +++
@@ -37,11 +40,13 @@ The best choice will depend on the usage.
    * - :class:`jaxopt.OSQP`
      - yes
      - yes
+     - yes
      - \+
      - ++
      - ++
      - (Q, c), (A, b), (G, h)
    * - :class:`jaxopt.BoxOSQP`
+     - yes
      - yes
      - yes
      - \+
@@ -51,6 +56,7 @@ The best choice will depend on the usage.
 
 - *jit*: the algorithm can be used with jit or vmap, on GPU/TPU.
 - *matvec*: the input can be given as matvec instead of dense matrices.
+- *fun*: the algorithm can be used with quadratic polynomial fun.
 - *precision*: accuracy expected when the solver succeeds to converge.
 - *stability*: capacity to handle badly scaled problems and matrices with poor conditioning.
 - *speed*: typical speed on big instances to reach its maximum accuracy.

--- a/jaxopt/_src/linear_operator.py
+++ b/jaxopt/_src/linear_operator.py
@@ -22,6 +22,13 @@ from jaxopt.tree_util import tree_map, tree_sum, tree_mul
 
 
 class DenseLinearOperator:
+  """General operator for dense matrices.
+  
+  Attributes:
+    pytree: pytree of dense matrices.
+      
+  Each leaf of ``pytree`` must be a 2D matrix.
+  """
 
   def __init__(self, pytree):
     self.pytree = pytree


### PR DESCRIPTION
## What's new ?

Classes `OSQP` and `BoxOSQP` now support the (optional) parameter `fun`: a function promised to be a quadratic convex polynomial. Any function that can be written on the form `fun(x, params_Q)=0.5xQx+cx+cste` for some PSD matrix Q.

The advantages of matrix-vector products are leveraged to avoid the explicit computation of `Q` at any time.

Pros:
- easy writing of objective function for fast prototyping
- no need to disantangle quadratic `0.5xQx` and affine `cx+cste` terms: useful for least squares objectives: `||y-x||_2`

Cons:
- more calls to `jax.grad` are now required to retrieve `jnp.dot(c, x)` and to perform `Qx` matrix-vectors products
- this overhead _could_ be (partially) alleviated by an efficient XLA compiler with Common Sub Expression Elimination

## Discussion

First, I wanted to use the approach evocated in https://github.com/google/jaxopt/issues/207 but `Q = jax.jacobian(grad)(zeros, params_obj)` is troublesome:
1. Q is no longer guaranteed to be a 2D matrix: this causes `DenseLinearOperator` to fail
2. Q is not strictly necessary, and often too big for practical applications

Related to point 1. I am slowly realizing that generalizing this approach to other solvers, and to other linear operators, will require to support arbitrary tensors (i.e not only 2D matrices). It can be formalized with the notion of covariant indices (input dimension) and contravariant indices (output dimensions): see [this table on wikipedia](https://en.wikipedia.org/wiki/Tensor#Examples) so I add some precision about DenseLinearOperator in the doc: it currently only support 2D matrices.  