### PR TITLE
Ensure the stepsize doesn't become too small.

### DIFF
--- a/jaxopt/_src/backtracking_linesearch.py
+++ b/jaxopt/_src/backtracking_linesearch.py
@@ -56,6 +56,7 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
     c2: constant strictly less than 1 used by the (strong) Wolfe condition.
     decrease_factor: factor by which to decrease the stepsize during line search
       (default: 0.8).
+    max_stepsize: upper bound on stepsize.
 
     maxiter: maximum number of line search iterations.
     tol: tolerance of the stopping criterion.
@@ -76,6 +77,7 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
   c1: float = 1e-4
   c2: float = 0.9
   decrease_factor: float = 0.8
+  max_stepsize: float = 1.0
 
   verbose: int = 0
   jit: base.AutoOrBoolean = "auto"
@@ -136,6 +138,9 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
     Returns:
       (params, state)
     """
+    # Ensure that stepsize does not exceed upper bound.
+    stepsize = jax.lax.min(self.max_stepsize, stepsize)
+
     if value is None or grad is None:
       value, grad = self._value_and_grad_fun(params, *args, **kwargs)
 

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -241,7 +241,6 @@ class LbfgsTest(test_util.JaxoptTestCase):
     # Check optimality conditions.
     self.assertLessEqual(info.error, 1e-2)
 
-  @absltest.skip
   def test_Rosenbrock(self):
     # optimize the Rosenbrock function.
     def fun(x, *args, **kwargs):


### PR DESCRIPTION
The test with line search on the Rosenbrock function is now passing. I've added a mechanism so that if the stepsize becomes less than `min_stepsize`, then we restart it. Unfortunately, it has to be done in every solver (`LBFGS`, `NonlinearCG`, ...) separately because we don't have an API mechanism to do it in `BacktrackingLinesearch`. If the gradient norm becomes too small, it may be better to disable line search and switch to constant stepsize but I haven't implemented it yet, as this would make the branch data-dependent.

CC @fabianp @junpenglao @Algue-Rythme 