### PR TITLE
Add zoom line search.

### DIFF
--- a/benchmarks/lbfgs_benchmark.py
+++ b/benchmarks/lbfgs_benchmark.py
@@ -1,0 +1,88 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark LBFGS implementation."""
+
+import time
+
+from absl import app
+from absl import flags
+
+from sklearn import datasets
+
+import jax
+import jax.numpy as jnp
+import jaxopt
+
+import numpy as onp
+
+import matplotlib.pyplot as plt
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer("maxiter", default=30, help="Max # of iterations.")
+flags.DEFINE_integer("n_samples", default=10000, help="Number of samples.")
+flags.DEFINE_integer("n_features", default=200, help="Number of features.")
+
+
+def binary_logreg(linesearch):
+  X, y = datasets.make_classification(n_samples=FLAGS.n_samples,
+                                      n_features=FLAGS.n_features,
+                                      n_classes=2,
+                                      n_informative=3,
+                                      random_state=0)
+  data = (X, y)
+  fun = jaxopt.objective.binary_logreg
+  init = jnp.zeros(X.shape[1])
+  lbfgs = jaxopt.LBFGS(fun=fun, linesearch=linesearch)
+  state = lbfgs.init_state(init, data=data)
+  errors = onp.zeros(FLAGS.maxiter)
+  params = init
+
+  for it in range(FLAGS.maxiter):
+    params, state = lbfgs.update(params, state, data=data)
+    errors[it] = state.error
+
+  return errors
+
+
+def run_binary_logreg():
+  errors_backtracking = binary_logreg("backtracking")
+  errors_zoom = binary_logreg("zoom")
+
+  plt.figure()
+  plt.plot(jnp.arange(FLAGS.maxiter), errors_backtracking, label="backtracking")
+  plt.plot(jnp.arange(FLAGS.maxiter), errors_zoom, label="zoom")
+  plt.xlabel("Iterations")
+  plt.ylabel("Gradient error")
+  plt.yscale("log")
+  plt.legend(loc="best")
+  plt.show()
+
+
+def main(argv):
+  if len(argv) > 1:
+    raise app.UsageError("Too many command-line arguments.")
+
+  print("n_samples:", FLAGS.n_samples)
+  print("n_features:", FLAGS.n_features)
+  print("maxiter:", FLAGS.maxiter)
+  print()
+
+  run_binary_logreg()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/jaxopt/_src/zoom_linesearch.py
+++ b/jaxopt/_src/zoom_linesearch.py
@@ -1,0 +1,430 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zoom line search algorithm."""
+
+# Original code by Joshua George Albert:
+# https://github.com/google/jax/pull/3101
+
+from typing import NamedTuple, Union
+from functools import partial
+
+#from jax._src.numpy.util import _promote_dtypes_inexact
+import jax.numpy as jnp
+import jax
+from jax import lax
+
+_dot = partial(jnp.dot, precision=lax.Precision.HIGHEST)
+
+
+def _cubicmin(a, fa, fpa, b, fb, c, fc):
+  C = fpa
+  db = b - a
+  dc = c - a
+  denom = (db * dc) ** 2 * (db - dc)
+  d1 = jnp.array([[dc ** 2, -db ** 2],
+                  [-dc ** 3, db ** 3]])
+  A, B = _dot(d1, jnp.array([fb - fa - C * db, fc - fa - C * dc])) / denom
+
+  radical = B * B - 3. * A * C
+  xmin = a + (-B + jnp.sqrt(radical)) / (3. * A)
+
+  return xmin
+
+
+def _quadmin(a, fa, fpa, b, fb):
+  D = fa
+  C = fpa
+  db = b - a
+  B = (fb - D - C * db) / (db ** 2)
+  xmin = a - C / (2. * B)
+  return xmin
+
+
+def _binary_replace(replace_bit, original_dict, new_dict, keys=None):
+  if keys is None:
+    keys = new_dict.keys()
+  out = dict()
+  for key in keys:
+    out[key] = jnp.where(replace_bit, new_dict[key], original_dict[key])
+  return out
+
+
+class _ZoomState(NamedTuple):
+  done: Union[bool, jnp.ndarray]
+  failed: Union[bool, jnp.ndarray]
+  j: Union[int, jnp.ndarray]
+  a_lo: Union[float, jnp.ndarray]
+  phi_lo: Union[float, jnp.ndarray]
+  dphi_lo: Union[float, jnp.ndarray]
+  a_hi: Union[float, jnp.ndarray]
+  phi_hi: Union[float, jnp.ndarray]
+  dphi_hi: Union[float, jnp.ndarray]
+  a_rec: Union[float, jnp.ndarray]
+  phi_rec: Union[float, jnp.ndarray]
+  a_star: Union[float, jnp.ndarray]
+  phi_star: Union[float, jnp.ndarray]
+  dphi_star: Union[float, jnp.ndarray]
+  g_star: Union[float, jnp.ndarray]
+  nfev: Union[int, jnp.ndarray]
+  ngev: Union[int, jnp.ndarray]
+
+
+def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
+          dphi_lo, a_hi, phi_hi, dphi_hi, g_0, pass_through):
+  """
+  Implementation of zoom. Algorithm 3.6 from Wright and Nocedal, 'Numerical
+  Optimization', 1999, pg. 59-61. Tries cubic, quadratic, and bisection methods
+  of zooming.
+  """
+  state = _ZoomState(
+      done=False,
+      failed=False,
+      j=0,
+      a_lo=a_lo,
+      phi_lo=phi_lo,
+      dphi_lo=dphi_lo,
+      a_hi=a_hi,
+      phi_hi=phi_hi,
+      dphi_hi=dphi_hi,
+      a_rec=(a_lo + a_hi) / 2.,
+      phi_rec=(phi_lo + phi_hi) / 2.,
+      a_star=1.,
+      phi_star=phi_lo,
+      dphi_star=dphi_lo,
+      g_star=g_0,
+      nfev=0,
+      ngev=0,
+  )
+  delta1 = 0.2
+  delta2 = 0.1
+
+  def body(state):
+    # Body of zoom algorithm. We use boolean arithmetic to avoid using jax.cond
+    # so that it works on GPU/TPU.
+    dalpha = (state.a_hi - state.a_lo)
+    a = jnp.minimum(state.a_hi, state.a_lo)
+    b = jnp.maximum(state.a_hi, state.a_lo)
+    cchk = delta1 * dalpha
+    qchk = delta2 * dalpha
+
+    # This will cause the line search to stop, and since the Wolfe conditions
+    # are not satisfied the minimization should stop too.
+    threshold = jnp.where((jnp.finfo(dalpha).bits < 64), 1e-5, 1e-10)
+    state = state._replace(failed=state.failed | (dalpha <= threshold))
+
+    # Cubmin is sometimes nan, though in this case the bounds check will fail.
+    a_j_cubic = _cubicmin(state.a_lo, state.phi_lo, state.dphi_lo, state.a_hi,
+                          state.phi_hi, state.a_rec, state.phi_rec)
+    use_cubic = (state.j > 0) & (a_j_cubic > a + cchk) & (a_j_cubic < b - cchk)
+    a_j_quad = _quadmin(state.a_lo, state.phi_lo, state.dphi_lo, state.a_hi, state.phi_hi)
+    use_quad = (~use_cubic) & (a_j_quad > a + qchk) & (a_j_quad < b - qchk)
+    a_j_bisection = (state.a_lo + state.a_hi) / 2.
+    use_bisection = (~use_cubic) & (~use_quad)
+
+    a_j = jnp.where(use_cubic, a_j_cubic, state.a_rec)
+    a_j = jnp.where(use_quad, a_j_quad, a_j)
+    a_j = jnp.where(use_bisection, a_j_bisection, a_j)
+
+    # TODO(jakevdp): should we use some sort of fixed-point approach here instead?
+    phi_j, dphi_j, g_j = restricted_func_and_grad(a_j)
+    phi_j = phi_j.astype(state.phi_lo.dtype)
+    dphi_j = dphi_j.astype(state.dphi_lo.dtype)
+    g_j = g_j.astype(state.g_star.dtype)
+    state = state._replace(nfev=state.nfev + 1,
+                           ngev=state.ngev + 1)
+
+    hi_to_j = wolfe_one(a_j, phi_j) | (phi_j >= state.phi_lo)
+    star_to_j = wolfe_two(dphi_j) & (~hi_to_j)
+    hi_to_lo = (dphi_j * (state.a_hi - state.a_lo) >= 0.) & (~hi_to_j) & (~star_to_j)
+    lo_to_j = (~hi_to_j) & (~star_to_j)
+
+    state = state._replace(
+        **_binary_replace(
+            hi_to_j,
+            state._asdict(),
+            dict(
+                a_hi=a_j,
+                phi_hi=phi_j,
+                dphi_hi=dphi_j,
+                a_rec=state.a_hi,
+                phi_rec=state.phi_hi,
+            ),
+        ),
+    )
+
+    # for termination
+    state = state._replace(
+        done=star_to_j | state.done,
+        **_binary_replace(
+            star_to_j,
+            state._asdict(),
+            dict(
+                a_star=a_j,
+                phi_star=phi_j,
+                dphi_star=dphi_j,
+                g_star=g_j,
+            )
+        ),
+    )
+    state = state._replace(
+        **_binary_replace(
+            hi_to_lo,
+            state._asdict(),
+            dict(
+                a_hi=state.a_lo,
+                phi_hi=state.phi_lo,
+                dphi_hi=state.dphi_lo,
+                a_rec=state.a_hi,
+                phi_rec=state.phi_hi,
+            ),
+        ),
+    )
+    state = state._replace(
+        **_binary_replace(
+            lo_to_j,
+            state._asdict(),
+            dict(
+                a_lo=a_j,
+                phi_lo=phi_j,
+                dphi_lo=dphi_j,
+                a_rec=state.a_lo,
+                phi_rec=state.phi_lo,
+            ),
+        ),
+    )
+    state = state._replace(j=state.j + 1)
+    # Choose higher cutoff for maxiter than Scipy as Jax takes longer to find
+    # the same value - possibly floating point issues?
+    state = state._replace(failed= state.failed | (state.j >= 30))
+    return state
+
+  state = lax.while_loop(lambda state: (~state.done) & (~pass_through) & (~state.failed),
+                         body,
+                         state)
+
+  return state
+
+
+class _LineSearchState(NamedTuple):
+  done: Union[bool, jnp.ndarray]
+  failed: Union[bool, jnp.ndarray]
+  i: Union[int, jnp.ndarray]
+  a_i1: Union[float, jnp.ndarray]
+  phi_i1: Union[float, jnp.ndarray]
+  dphi_i1: Union[float, jnp.ndarray]
+  nfev: Union[int, jnp.ndarray]
+  ngev: Union[int, jnp.ndarray]
+  a_star: Union[float, jnp.ndarray]
+  phi_star: Union[float, jnp.ndarray]
+  dphi_star: Union[float, jnp.ndarray]
+  g_star: jnp.ndarray
+
+
+class _LineSearchResults(NamedTuple):
+  """Results of line search.
+  Parameters:
+    failed: True if the strong Wolfe criteria were satisfied
+    nit: integer number of iterations
+    nfev: integer number of functions evaluations
+    ngev: integer number of gradients evaluations
+    k: integer number of iterations
+    a_k: integer step size
+    f_k: final function value
+    g_k: final gradient value
+    status: integer end status
+  """
+  failed: Union[bool, jnp.ndarray]
+  nit: Union[int, jnp.ndarray]
+  nfev: Union[int, jnp.ndarray]
+  ngev: Union[int, jnp.ndarray]
+  k: Union[int, jnp.ndarray]
+  a_k: Union[int, jnp.ndarray]
+  f_k: jnp.ndarray
+  g_k: jnp.ndarray
+  status: Union[bool, jnp.ndarray]
+
+
+def zoom_linesearch(f, xk, pk, old_fval=None, old_old_fval=None, gfk=None, c1=1e-4,
+                c2=0.9, maxiter=20):
+  """Inexact line search that satisfies strong Wolfe conditions.
+  Algorithm 3.5 from Wright and Nocedal, 'Numerical Optimization', 1999, pg. 59-61
+  Args:
+    fun: function of the form f(x) where x is a flat ndarray and returns a real
+      scalar. The function should be composed of operations with vjp defined.
+    x0: initial guess.
+    pk: direction to search in. Assumes the direction is a descent direction.
+    old_fval, gfk: initial value of value_and_gradient as position.
+    old_old_fval: unused argument, only for scipy API compliance.
+    maxiter: maximum number of iterations to search
+    c1, c2: Wolfe criteria constant, see ref.
+  Returns: LineSearchResults
+  """
+  #xk, pk = _promote_dtypes_inexact(xk, pk)
+  xk = jnp.asarray(xk)
+  pk = jnp.asarray(pk)
+
+  def restricted_func_and_grad(t):
+    t = jnp.array(t, dtype=pk.dtype)
+    # FIXME: directly acept a value_and_grad function to avoid recompilations.
+    phi, g = jax.value_and_grad(f)(xk + t * pk)
+    dphi = jnp.real(_dot(g, pk))
+    return phi, dphi, g
+
+  if old_fval is None or gfk is None:
+    phi_0, dphi_0, gfk = restricted_func_and_grad(0)
+  else:
+    phi_0 = old_fval
+    dphi_0 = jnp.real(_dot(gfk, pk))
+  if old_old_fval is not None:
+    candidate_start_value = 1.01 * 2 * (phi_0 - old_old_fval) / dphi_0
+    start_value = jnp.where(candidate_start_value > 1, 1.0, candidate_start_value)
+  else:
+    start_value = 1
+
+  def wolfe_one(a_i, phi_i):
+    # actually negation of W1
+    return phi_i > phi_0 + c1 * a_i * dphi_0
+
+  def wolfe_two(dphi_i):
+    return jnp.abs(dphi_i) <= -c2 * dphi_0
+
+  state = _LineSearchState(
+      done=False,
+      failed=False,
+      # algorithm begins at 1 as per Wright and Nocedal, however Scipy has a
+      # bug and starts at 0. See https://github.com/scipy/scipy/issues/12157
+      i=1,
+      a_i1=0.,
+      phi_i1=phi_0,
+      dphi_i1=dphi_0,
+      nfev=1 if (old_fval is None or gfk is None) else 0,
+      ngev=1 if (old_fval is None or gfk is None) else 0,
+      a_star=0.,
+      phi_star=phi_0,
+      dphi_star=dphi_0,
+      g_star=gfk,
+  )
+
+  def body(state):
+    # no amax in this version, we just double as in scipy.
+    # unlike original algorithm we do our next choice at the start of this loop
+    a_i = jnp.where(state.i == 1, start_value, state.a_i1 * 2.)
+
+    phi_i, dphi_i, g_i = restricted_func_and_grad(a_i)
+    state = state._replace(nfev=state.nfev + 1,
+                           ngev=state.ngev + 1)
+
+    star_to_zoom1 = wolfe_one(a_i, phi_i) | ((phi_i >= state.phi_i1) & (state.i > 1))
+    star_to_i = wolfe_two(dphi_i) & (~star_to_zoom1)
+    star_to_zoom2 = (dphi_i >= 0.) & (~star_to_zoom1) & (~star_to_i)
+
+    zoom1 = _zoom(restricted_func_and_grad,
+                  wolfe_one,
+                  wolfe_two,
+                  state.a_i1,
+                  state.phi_i1,
+                  state.dphi_i1,
+                  a_i,
+                  phi_i,
+                  dphi_i,
+                  gfk,
+                  ~star_to_zoom1)
+
+    state = state._replace(nfev=state.nfev + zoom1.nfev,
+                           ngev=state.ngev + zoom1.ngev)
+
+    zoom2 = _zoom(restricted_func_and_grad,
+                  wolfe_one,
+                  wolfe_two,
+                  a_i,
+                  phi_i,
+                  dphi_i,
+                  state.a_i1,
+                  state.phi_i1,
+                  state.dphi_i1,
+                  gfk,
+                  ~star_to_zoom2)
+
+    state = state._replace(nfev=state.nfev + zoom2.nfev,
+                           ngev=state.ngev + zoom2.ngev)
+
+    state = state._replace(
+        done=star_to_zoom1 | state.done,
+        failed=(star_to_zoom1 & zoom1.failed) | state.failed,
+        **_binary_replace(
+            star_to_zoom1,
+            state._asdict(),
+            zoom1._asdict(),
+            keys=['a_star', 'phi_star', 'dphi_star', 'g_star'],
+        ),
+    )
+    state = state._replace(
+        done=star_to_i | state.done,
+        **_binary_replace(
+            star_to_i,
+            state._asdict(),
+            dict(
+                a_star=a_i,
+                phi_star=phi_i,
+                dphi_star=dphi_i,
+                g_star=g_i,
+            ),
+        ),
+    )
+    state = state._replace(
+        done=star_to_zoom2 | state.done,
+        failed=(star_to_zoom2 & zoom2.failed) | state.failed,
+        **_binary_replace(
+            star_to_zoom2,
+            state._asdict(),
+            zoom2._asdict(),
+            keys=['a_star', 'phi_star', 'dphi_star', 'g_star'],
+        ),
+    )
+    state = state._replace(i=state.i + 1, a_i1=a_i, phi_i1=phi_i, dphi_i1=dphi_i)
+    return state
+
+  state = lax.while_loop(lambda state: (~state.done) & (state.i <= maxiter) & (~state.failed),
+                         body,
+                         state)
+
+  status = jnp.where(
+      state.failed,
+      jnp.array(1),  # zoom failed
+          jnp.where(
+              state.i > maxiter,
+              jnp.array(3),  # maxiter reached
+              jnp.array(0),  # passed (should be)
+          ),
+  )
+  # Step sizes which are too small causes the optimizer to get stuck with a
+  # direction of zero in <64 bit mode - avoid with a floor on minimum step size.
+  alpha_k = state.a_star
+  alpha_k = jnp.where((jnp.finfo(alpha_k).bits != 64)
+                    & (jnp.abs(alpha_k) < 1e-8),
+                      jnp.sign(alpha_k) * 1e-8,
+                      alpha_k)
+  results = _LineSearchResults(
+      failed=state.failed | (~state.done),
+      nit=state.i - 1,  # because iterations started at 1
+      nfev=state.nfev,
+      ngev=state.ngev,
+      k=state.i,
+      a_k=alpha_k,
+      f_k=state.phi_star,
+      g_k=state.g_star,
+      status=status,
+  )
+  return results

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -203,8 +203,9 @@ class LbfgsTest(test_util.JaxoptTestCase):
 
     self.assertArraysAllClose(x1, x2, atol=1e-5)
 
-  @parameterized.product(use_gamma=[True, False])
-  def test_binary_logreg(self, use_gamma):
+  @parameterized.product(use_gamma=[True, False],
+                         linesearch=["backtracking", "zoom"])
+  def test_binary_logreg(self, use_gamma, linesearch):
     X, y = datasets.make_classification(n_samples=10, n_features=5,
                                         n_classes=2, n_informative=3,
                                         random_state=0)
@@ -212,7 +213,8 @@ class LbfgsTest(test_util.JaxoptTestCase):
     fun = objective.binary_logreg
 
     w_init = jnp.zeros(X.shape[1])
-    lbfgs = LBFGS(fun=fun, tol=1e-3, maxiter=500, use_gamma=use_gamma)
+    lbfgs = LBFGS(fun=fun, tol=1e-3, maxiter=500, use_gamma=use_gamma,
+                  linesearch=linesearch)
     # Test with keyword argument.
     w_fit, info = lbfgs.run(w_init, data=data)
 

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -1,0 +1,162 @@
+from absl.testing import absltest, parameterized
+import scipy.optimize
+
+from jax import grad
+import jax.numpy as jnp
+import numpy as onp
+
+from jaxopt._src import test_util
+from jaxopt._src.zoom_linesearch import zoom_linesearch
+
+
+class ZoomLinesearchTest(test_util.JaxoptTestCase):
+  # -- scalar functions; must have dphi(0.) < 0
+
+  def setUp(self):
+    self.rng = lambda : onp.random.RandomState(0)
+
+  def assert_wolfe(self, s, phi, derphi, c1=1e-4, c2=0.9, err_msg=""):
+    """
+    Check that strong Wolfe conditions apply
+    """
+    phi1 = phi(s)
+    phi0 = phi(0)
+    derphi0 = derphi(0)
+    derphi1 = derphi(s)
+    msg = "s = {}; phi(0) = {}; phi(s) = {}; phi'(0) = {}; phi'(s) = {}; {}".format(
+      s, phi0, phi1, derphi0, derphi1, err_msg)
+
+    self.assertTrue(phi1 <= phi0 + c1 * s * derphi0, "Wolfe 1 failed: " + msg)
+    self.assertTrue(abs(derphi1) <= abs(c2 * derphi0), "Wolfe 2 failed: " + msg)
+
+  def assert_line_wolfe(self, x, p, s, f, fprime, **kw):
+    self.assert_wolfe(s, phi=lambda sp: f(x + p * sp),
+                      derphi=lambda sp: jnp.dot(fprime(x + p * sp), p), **kw)
+
+  def _scalar_func_1(self, s):
+    p = -s - s ** 3 + s ** 4
+    dp = -1 - 3 * s ** 2 + 4 * s ** 3
+    return p, dp
+
+  def _scalar_func_2(self, s):
+    p = jnp.exp(-4 * s) + s ** 2
+    dp = -4 * jnp.exp(-4 * s) + 2 * s
+    return p, dp
+
+  def _scalar_func_3(self, s):
+    p = -jnp.sin(10 * s)
+    dp = -10 * jnp.cos(10 * s)
+    return p, dp
+
+  # -- n-d functions
+
+  def _line_func_1(self, x):
+    f = jnp.dot(x, x)
+    df = 2 * x
+    return f, df
+
+  def _line_func_2(self, x):
+    f = jnp.dot(x, jnp.dot(self.A, x)) + 1
+    df = jnp.dot(self.A + self.A.T, x)
+    return f, df
+
+  # -- Generic scalar searches
+
+  @parameterized.product(name=["_scalar_func_1",
+                               "_scalar_func_2",
+                               "_scalar_func_3"])
+  def test_scalar_search_wolfe2(self, name):
+
+    def bind_index(func, idx):
+      # Remember Python's closure semantics!
+      return lambda *a, **kw: func(*a, **kw)[idx]
+
+    value = getattr(self, name)
+    phi = bind_index(value, 0)
+    derphi = bind_index(value, 1)
+    for old_phi0 in self.rng().randn(3):
+      res = zoom_linesearch(phi, 0., 1.)
+      s, phi1, derphi1 = res.a_k, res.f_k, res.g_k
+      self.assertAllClose(phi1, phi(s), check_dtypes=False, atol=1e-6)
+      if derphi1 is not None:
+        self.assertAllClose(derphi1, derphi(s), check_dtypes=False, atol=1e-6)
+      self.assert_wolfe(s, phi, derphi, err_msg=f"{name} {old_phi0:g}")
+
+  # -- Generic line searches
+
+  @parameterized.product(name=["_line_func_1", "_line_func_2"])
+  def test_line_search_wolfe2(self, name):
+    def bind_index(func, idx):
+      # Remember Python's closure semantics!
+      return lambda *a, **kw: func(*a, **kw)[idx]
+
+    value = getattr(self, name)
+    f = bind_index(value, 0)
+    fprime = bind_index(value, 1)
+
+    k = 0
+    N = 20
+    rng = self.rng()
+    # sets A in one of the line funcs
+    self.A = self.rng().randn(N, N)
+    while k < 9:
+      x = rng.randn(N)
+      p = rng.randn(N)
+      if jnp.dot(p, fprime(x)) >= 0:
+        # always pick a descent pk
+        continue
+      k += 1
+
+      f0 = f(x)
+      g0 = fprime(x)
+      self.fcount = 0
+      res = zoom_linesearch(f, x, p, old_fval=f0, gfk=g0)
+      s = res.a_k
+      fv = res.f_k
+      gv = res.g_k
+      self.assertAllClose(fv, f(x + s * p), check_dtypes=False, atol=1e-5)
+      if gv is not None:
+        self.assertAllClose(gv, fprime(x + s * p), check_dtypes=False, atol=1e-5)
+
+  def test_line_search_wolfe2_bounds(self):
+    # See gh-7475
+
+    # For this f and p, starting at a point on axis 0, the strong Wolfe
+    # condition 2 is met if and only if the step length s satisfies
+    # |x + s| <= c2 * |x|
+    f = lambda x: jnp.dot(x, x)
+    fp = lambda x: 2 * x
+    p = jnp.array([1.0, 0.0])
+
+    # Smallest s satisfying strong Wolfe conditions for these arguments is 30
+    x = -60 * p
+    c2 = 0.5
+
+    res = zoom_linesearch(f, x, p, c2=c2)
+    s = res.a_k
+    # s, _, _, _, _, _ = ls.zoom_linesearch(f, fp, x, p, amax=30, c2=c2)
+    self.assert_line_wolfe(x, p, s, f, fp)
+    self.assertTrue(s >= 30.)
+
+    res = zoom_linesearch(f, x, p, c2=c2, maxiter=5)
+    self.assertTrue(res.failed)
+    # s=30 will only be tried on the 6th iteration, so this won't converge
+
+  def test_line_search(self):
+
+    def f(x):
+      return jnp.cos(jnp.sum(jnp.exp(-x)) ** 2)
+
+    # assert not zoom_linesearch(jax.value_and_grad(f), np.ones(2), np.array([-0.5, -0.25])).failed
+    xk = jnp.ones(2)
+    pk = jnp.array([-0.5, -0.25])
+    res = zoom_linesearch(f, xk, pk, maxiter=100)
+
+    scipy_res = scipy.optimize.line_search(f, grad(f), xk, pk)
+
+    self.assertAllClose(scipy_res[0], res.a_k, atol=1e-5, check_dtypes=False)
+    self.assertAllClose(scipy_res[3], res.f_k, atol=1e-5, check_dtypes=False)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This PR is the first of a series of PRs to integrate zoom line search in JAXopt. It uses the code of @Joshuaalbert currently in JAX core. It supports only 1d arrays for parameters at the moment.

To be done in other PRs:

1) write more correctness tests, e.g. tests for isolated functions  such as `quadmin` or `cubicmin`
2) simplify the code when possible
3) add pytree support, either natively or via flattening
4) benchmarks: backtracking vs. zoom, SciPy vs. JAXopt on various problems (both convex and nonconvex) 
5) use our iterative solver API instead of using a lax.while_loop (this will give access to individual steps of the line search)

CC: @shoyer @jakevdp @junpenglao