### PR TITLE
Support value_and_grad in zoom line search.

### DIFF
--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -295,9 +295,11 @@ class LBFGS(base.IterativeSolver):
         new_grad = ls_state.grad
 
       elif self.linesearch == "zoom":
-        fun = lambda p: self._fun(p, *args, **kwargs)
-        ls_state = zoom_linesearch(f=fun, xk=params, pk=descent_direction,
-                              old_fval=value, gfk=grad, maxiter=self.maxls)
+        ls_state = zoom_linesearch(f=self._value_and_grad_with_aux,
+                                   xk=params, pk=descent_direction,
+                                   old_fval=value, gfk=grad, maxiter=self.maxls,
+                                   value_and_grad=True, has_aux=True,
+                                   args=args, kwargs=kwargs)
         new_value = ls_state.f_k
         new_stepsize = ls_state.a_k
         new_grad = ls_state.g_k

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -1,7 +1,7 @@
 from absl.testing import absltest, parameterized
 import scipy.optimize
 
-from jax import grad
+import jax
 import jax.numpy as jnp
 import numpy as onp
 
@@ -151,11 +151,14 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
     xk = jnp.ones(2)
     pk = jnp.array([-0.5, -0.25])
     res = zoom_linesearch(f, xk, pk, maxiter=100)
-
-    scipy_res = scipy.optimize.line_search(f, grad(f), xk, pk)
+    res2 = zoom_linesearch(jax.value_and_grad(f), xk, pk, maxiter=100,
+                           value_and_grad=True)
+    scipy_res = scipy.optimize.line_search(f, jax.grad(f), xk, pk)
 
     self.assertAllClose(scipy_res[0], res.a_k, atol=1e-5, check_dtypes=False)
     self.assertAllClose(scipy_res[3], res.f_k, atol=1e-5, check_dtypes=False)
+    self.assertAllClose(scipy_res[0], res2.a_k, atol=1e-5, check_dtypes=False)
+    self.assertAllClose(scipy_res[3], res2.f_k, atol=1e-5, check_dtypes=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`value_and_grad` is already computed within LBFGS so we save a compilation by not recomputing it within the zoom line search.