### PR TITLE
Allow formulas to be well displayed in html pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,6 +122,7 @@ html_css_files = [
 nb_execution_mode = "force"
 nb_execution_allow_errors = False
 nb_execution_fail_on_error = True  # Requires https://github.com/executablebooks/MyST-NB/pull/296
+myst_enable_extensions = ['dollarmath'] # To display maths in notebook
 
 # Notebook cell execution timeout; defaults to 30.
 nb_execution_timeout = 100


### PR DESCRIPTION
nbsphinx seems to be the right extension to display formulas from notebooks.
I removed the source_suffix list because of https://github.com/spatialaudio/nbsphinx/issues/310. So we shouldn't put ipynb in the extension list (to use nbsphinx), but if we just keep md and rst, the whole notebook appears raw.

I also had to remove the myst-nb extension that seemed in conflict with nbsphinx.