### PR TITLE
Sparse root VJP for Lasso penalty

### DIFF
--- a/benchmarks/sparse_root_vjp_benchmark.py
+++ b/benchmarks/sparse_root_vjp_benchmark.py
@@ -56,9 +56,12 @@ def benchmark_vjp(vjp, X, supp=None, desc=''):
   result.block_until_ready()
   delta_t = time.time() - t0
 
+  size_support = onp.sum(result != 0)
+
   if supp is not None:
     result = result[supp]
-  print(f'{desc} ({delta_t:.3f} sec.): {result}')
+  print(f'{desc} ({delta_t:.3f} sec.): {result} '
+        f'(size of the support: {size_support:d})')
 
 
 def main(argv: Sequence[str]) -> None:

--- a/benchmarks/sparse_root_vjp_benchmark.py
+++ b/benchmarks/sparse_root_vjp_benchmark.py
@@ -1,0 +1,110 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark VJP of Lasso, with and without specifying the support."""
+
+import time
+import numpy as onp
+import jax
+import jax.numpy as jnp
+
+from typing import Sequence
+from absl import app
+from sklearn import datasets
+
+from jaxopt import implicit_diff as idf
+from jaxopt._src import linear_solve
+from jaxopt import objective
+from jaxopt import prox
+from jaxopt import support
+from jaxopt import tree_util
+from jaxopt._src import test_util
+
+
+def lasso_optimality_fun(params, lam, X, y):
+  step = params - jax.grad(objective.least_squares)(params, (X, y))
+  return prox.prox_lasso(step, l1reg=lam, scaling=1.) - params
+
+
+def get_vjp(lam, X, y, sol, support_fun, maxiter, jit=False):
+    def solve(matvec, b):
+      return linear_solve.solve_cg(matvec, b, tol=1e-6, maxiter=maxiter)
+
+    vjp = lambda g: idf.root_vjp(optimality_fun=lasso_optimality_fun,
+                                 support_fun=support_fun,
+                                 sol=sol,
+                                 args=(lam, X, y),
+                                 cotangent=g,
+                                 solve=solve)[0]
+    if jit:
+      vjp = jax.jit(vjp)
+    return vjp
+
+
+def benchmark_vjp(vjp, X, supp=None, desc=''):
+  t0 = time.time()
+  result = jax.vmap(vjp)(jnp.eye(X.shape[1]))
+  result.block_until_ready()
+  delta_t = time.time() - t0
+
+  if supp is not None:
+    result = result[supp]
+  print(f'{desc} ({delta_t:.3f} sec.): {result}')
+
+
+def main(argv: Sequence[str]) -> None:
+  if len(argv) > 1:
+    raise app.UsageError("Too many command-line arguments.")
+
+  X, y = datasets.make_regression(n_samples=100, n_features=1000,
+                                  n_informative=5, random_state=0)
+  print(f'Number of samples: {X.shape[0]:d}')
+  print(f'Number of features: {X.shape[1]:d}')
+
+  lam = 1e-3 * onp.max(X.T @ y)
+  print(f'Value of lambda: {lam:.5f}')
+
+  sol = test_util.lasso_skl(X, y, lam, tol=1e-6, fit_intercept=False)
+  supp = (sol != 0)
+  print(f'Size of the support of the solution: {supp.sum():d}')
+
+  optimality = tree_util.tree_l2_norm(lasso_optimality_fun(sol, lam, X, y))
+  print(f'Optimality of the solution (L2-norm): {optimality:.5f}')
+
+  jac_num = test_util.lasso_skl_jac(X, y, lam, eps=1e-8)
+  print(f'Numerical Jacobian: {jac_num[supp]}')
+
+  # Compute the Jacobian wrt. lambda, without using the information about the
+  # support of the solution. This is the default behavior in JAXopt, and
+  # requires solving a linear system with a 1000x1000 dense matrix. Ignoring
+  # the support of the solution leads to an inacurrate Jacobian.
+  vjp = get_vjp(lam, X, y, sol, support.support_all, maxiter=1000, jit=False)
+  benchmark_vjp(vjp, X, supp=supp, desc='Jacobian w/o support')
+
+  # Compute the Jacobian wrt. lambda, restricting the data X and the solution
+  # to the support of the solution. This requires solving a linear system with
+  # a 4x4 dense matrix. Restricting the support this way is not jit-friendly,
+  # and will require new compilation if the size of the support changes.
+  vjp = get_vjp(lam, X[:, supp], y, sol[supp], support.support_all, maxiter=1000, jit=False)
+  benchmark_vjp(vjp, X[:, supp], desc='Jacobian w/ restricted support')
+
+  # Compute the Jacobian wrt. lambda, by masking the linear system to solve
+  # with the support of the solution. This requires solving a linear system with
+  # a 1000x1000 sparse matrix. Masking with the support is jit-friendly.
+  vjp = get_vjp(lam, X, y, sol, support.support_nonzero, maxiter=1000, jit=False)
+  benchmark_vjp(vjp, X, supp=supp, desc='Jacobian w/ masked support')
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/docs/implicit_diff.rst
+++ b/docs/implicit_diff.rst
@@ -58,6 +58,26 @@ We can also compose ``ridge_reg_solution`` with other functions::
    * :ref:`sphx_glr_auto_examples_implicit_diff_lasso_implicit_diff.py`
    * :ref:`sphx_glr_auto_examples_implicit_diff_sparse_coding.py`
 
+Non-smooth functions
+--------------------
+
+When the function :math:`f(x, \theta)` is non-smooth (e.g., in Lasso), implicit
+differentiation can still be applied to compute the Jacobian
+:math:`\partial x^\star(\theta)`. However, the linear system to solve to obtain
+the Jacobian (or, alternatively, the vector-Jacobian product) must be restricted
+to the (generalized) *support* :math:`S` of the solution :math:`x^\star`. To
+give a hint to the linear solver called in ``root_vjp``, you may specify a
+support function ``support`` that will restrict the linear system to the support
+of the solution.
+
+The ``support`` function must return a pytree with the same structure and dtype
+as the solution, where ``support(x)`` is equal to 1 for the coordinates :math:`j`
+in the support (:math:`x_{j} \in S`), and 0 otherwise. The support function
+depends on the non-smooth function being optimized; see :ref:`support functions
+<support_functions>` for examples of support functions. Note that the
+support function merely masks out coordinates outside of the support, making it
+fully compatible with ``jit`` compilation.
+
 Custom solvers
 --------------
 
@@ -92,3 +112,8 @@ of roots of functions.
    <https://arxiv.org/abs/2105.15183>`_,
    Mathieu Blondel, Quentin Berthet, Marco Cuturi, Roy Frostig, Stephan Hoyer, Felipe Llinares-López, Fabian Pedregosa, Jean-Philippe Vert.
    ArXiv preprint.
+
+ * `Implicit Differentiation for Fast Hyperparameter Selection in Non-Smooth Convex Learning
+   <https://www.jmlr.org/papers/volume23/21-0486/21-0486.pdf>`_,
+   Quentin Bertrand, Quentin Klopfenstein, Mathurin Massias, Mathieu Blondel, Samuel Vaiter, Alexandre Gramfort, Joseph Salmon.
+   Journal of Machine Learning Research (JMLR).

--- a/docs/non_smooth.rst
+++ b/docs/non_smooth.rst
@@ -82,6 +82,23 @@ and autodiff of unrolled iterations if ``implicit_diff=False``.  See the
    * :ref:`sphx_glr_auto_examples_implicit_diff_lasso_implicit_diff.py`
    * :ref:`sphx_glr_auto_examples_implicit_diff_sparse_coding.py`
 
+When using implicit differentiation, you can optionally specify a support
+function ``support`` to give a hint to the linear solver called in ``root_vjp``
+and only solve the linear system restricted to the support of the solution::
+
+  from jaxopt.support import support_nonzero
+
+  def solution(l1reg):
+    pg = ProximalGradient(fun=least_squares, prox=prox_lasso,
+                          support=support_nonzero, implicit_diff=True)
+    return pg.run(w_init, hyperparams_prox=l1reg, data=(X, y)).params
+
+  # Both the solution & the Jacobian have the same support
+  print(solution(l1reg))
+  print(jax.jacobian(solution)(l1reg))
+
+See the :ref:`implicit differentiation <implicit_diff>` section for more details.
+
 .. _block_coordinate_descent:
 
 Block coordinate descent
@@ -134,3 +151,24 @@ The following operators are available.
     jaxopt.prox.prox_group_lasso
     jaxopt.prox.prox_ridge
     jaxopt.prox.prox_non_negative_ridge
+
+.. _support_functions:
+
+Support functions
+-----------------
+
+Support functions of the form :math:`S(x)` that returns 1 for all the
+coordinates of :math:`x` in the support, and 0 otherwise:
+
+.. math::
+
+  S(x)_{j} := \begin{cases} 1 & \textrm{if $x_{j} \in S$} \\ 0 & \textrm{otherwise} \end{cases}
+
+The following support functions are available.
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.support.support_all
+    jaxopt.support.support_nonzero
+    jaxopt.support.support_group_nonzero

--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -204,10 +204,12 @@ class IterativeSolver(Solver):
     run = self._run
 
     if getattr(self, "implicit_diff", True):
+      support_fun = getattr(self, "support", None)
       reference_signature = getattr(self, "reference_signature", None)
       decorator = idf.custom_root(
           self.optimality_fun,
           has_aux=True,
+          support_fun=support_fun,
           solve=self.implicit_diff_solve,
           reference_signature=reference_signature)
       run = decorator(run)

--- a/jaxopt/_src/proximal_gradient.py
+++ b/jaxopt/_src/proximal_gradient.py
@@ -31,6 +31,7 @@ import jax.numpy as jnp
 from jaxopt._src import base
 from jaxopt._src import loop
 from jaxopt._src.prox import prox_none
+from jaxopt._src.support import support_all
 from jaxopt._src.tree_util import tree_add_scalar_mul
 from jaxopt._src.tree_util import tree_l2_norm
 from jaxopt._src.tree_util import tree_sub
@@ -104,6 +105,11 @@ class ProximalGradient(base.IterativeSolver):
     prox: proximity operator associated with the function ``non_smooth``.
       It should be of the form ``prox(params, hyperparams_prox, scale=1.0)``.
       See ``jaxopt.prox`` for examples.
+    support: a function of the form ``support(params)``, returning
+      the support of a pytree ``params``. This function returns a pytree with
+      the same structure and dtypes as ``params``, equal to 1 for the
+      coordinates of ``params`` in the support, and 0 otherwise.
+      See ``jaxopt.support`` for examples.
     stepsize: a stepsize to use (if <= 0, use backtracking line search),
       or a callable specifying the **positive** stepsize to use at each iteration.
     maxiter: maximum number of proximal gradient descent iterations.
@@ -130,6 +136,7 @@ class ProximalGradient(base.IterativeSolver):
   """
   fun: Callable
   prox: Callable = prox_none
+  support: Callable = support_all
   stepsize: Union[float, Callable] = 0.0
   maxiter: int = 500
   maxls: int = 15

--- a/jaxopt/_src/support.py
+++ b/jaxopt/_src/support.py
@@ -1,0 +1,82 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support functions."""
+
+from typing import Any
+
+import jax.numpy as jnp
+
+from jaxopt._src import tree_util
+
+
+def support_all(x: Any):
+  r"""Support function where all the coordinates are in the support.
+
+  If :math:`S` is the support set, then :math:`\forall i`, :math:`x_{i} \in S`.
+  
+  Args:
+    x: input pytree.
+  Returns
+    output pytree, with the same structure and dtypes as ``x``, where all the
+    coordinates equal to 1.
+  """
+  return tree_util.tree_map(jnp.ones_like, x)
+
+
+def support_nonzero(x: Any):
+  r"""Support function where the support corresponds to non-zero coordinates.
+
+  If :math:`S` is the support set, then :math:`\forall i`,
+
+  .. math::
+
+    x_{i} \in S \Leftrightarrow x_{i} \neq 0
+  
+  This support function is typically used for sparse objects with unstructured
+  sparsity patterns, e.g., with the operators ``jaxopt.prox.prox_lasso`` or
+  ``jaxopt.prox.prox_elastic_net``.
+
+  Args:
+    x: input pytree.
+  Returns
+    output pytree, with the same structure and dtypes as ``x``, equal to 1
+    if ``x[i] != 0``, and 0 otherwise.
+  """
+  fun = lambda u: (u != 0).astype(u.dtype)
+  return tree_util.tree_map(fun, x)
+
+
+def support_group_nonzero(x: Any):
+  r"""Support function where the support corresponds to groups of non-zero
+  coordinates.
+
+  If :math:`S` is the support set, then :math:`\forall i`,
+
+  .. math::
+    x_{i} \in S \Leftrightarrow x \not\equiv 0
+
+  Blocks can be grouped using ``jax.vmap``. This support function is typically
+  used for sparse objects with structured sparsity patterns, e.g., with the
+  operator ``jaxopt.prox.prox_group_lasso``.
+
+  Args:
+    x: input pytree.
+  Returns
+    output pytree, with the same structure and dtypes as ``x``, where all the
+    coordinates are equal to 1 if there exists an ``x[i] != 0``, and all equal
+    to 0 otherwise.
+  """
+  fun = lambda u: jnp.any(u != 0) * jnp.ones_like(u)
+  return tree_util.tree_map(fun, x)

--- a/jaxopt/support.py
+++ b/jaxopt/support.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jaxopt._src.support import support_all
+from jaxopt._src.support import support_nonzero
+from jaxopt._src.support import support_group_nonzero

--- a/tests/implicit_diff_test.py
+++ b/tests/implicit_diff_test.py
@@ -126,7 +126,7 @@ class ImplicitDiffTest(test_util.JaxoptTestCase):
       support.support_nonzero(sol).sum()
     )
 
-    # Compute the Jacobian matrix with the permuted solution, and verify
+    # Compute the Jacobian matrix with the smaller-support solution, and verify
     # that the function `jacobian` has only been compiled once (no
     # recompilation necessary, despite a smaller support).
     J_sub = jacobian(I, sol_sub, X)

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -32,6 +32,10 @@ class ImportTest(test_util.JaxoptTestCase):
     jaxopt.projection.projection_simplex
     from jaxopt.projection import projection_simplex
 
+  def test_support(self):
+    jaxopt.support.support_all
+    from jaxopt.support import support_all
+
   def test_tree_util(self):
     from jaxopt.tree_util import tree_vdot
 

--- a/tests/support_test.py
+++ b/tests/support_test.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+from jaxopt import support
+from jaxopt._src import test_util
+
+import numpy as onp
+
+
+class SupportTest(test_util.JaxoptTestCase):
+
+  def test_support_all(self):
+    rng = onp.random.RandomState(0)
+    x = rng.rand(20) * 2 - 1
+    supp = onp.ones_like(x)
+    self.assertArraysEqual(support.support_all(x), supp)
+
+  def test_support_nonzero(self):
+    rng = onp.random.RandomState(0)
+    x = rng.rand(20) * 2 - 1
+    x = onp.where(x > 0, x, 0)
+    supp = (x != 0).astype(x.dtype)
+    self.assertArraysEqual(support.support_nonzero(x), supp)
+
+  def test_support_group_nonzero(self):
+    rng = onp.random.RandomState(0)
+
+    x = rng.rand(20) * 2 - 1
+    x = onp.where(x > 0, x, 0)
+    self.assertFalse(onp.all(x == 0))
+    supp = onp.ones_like(x)
+    self.assertArraysEqual(support.support_group_nonzero(x), supp)
+
+    x = onp.zeros(20)
+    supp = onp.zeros_like(x)
+    self.assertArraysEqual(support.support_group_nonzero(x), supp)
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
We have been working with @QB3 on a rework of #17, adding support functions to enable implicit differentiation with sparsity-inducing penalties. The main difference is that we are masking the linear system to solve in `root_vjp` based on the support of the solution, instead of restricting it to its support, in order to be jit-compatible. For now, this functionality has only been added to `ProximalGradient`, but we can add it to other solvers as well if we agree on the API.

Specifying the support explicitly allows us to ensure that the Jacobian will be non-zero only for coordinates in the support of the solution. In the case of Lasso, this also allows us to use CG to solve the linear system, instead of Normal-CG, since we ensure that the matrix to invert is symmetric. We have written a benchmark to showcase the advantages of masking the linear system to the support only in Lasso:
```
Number of samples: 100
Number of features: 1000
Size of the support of the solution: 4
Numerical Jacobian: [-0.64471806 -0.72820061 -0.87170093 -0.76674667]
Jacobian w/o support, CG (14.901 sec.): [ 1.6838026e+09 -2.0496195e+09  1.6045356e+09  1.1004994e+08] (size of the support: 4)
Jacobian w/o support, normal CG (2.114 sec.): [-0.644696   -0.7282007  -0.8717052  -0.76675165] (size of the support: 1000)
Jacobian w/ restricted support (1.404 sec.): [-0.6446959  -0.7282008  -0.8717053  -0.76675177] (size of the support: 4)
Jacobian w/ masked support (1.482 sec.): [-0.64469576 -0.72820073 -0.87170535 -0.76675177] (size of the support: 4)
```

(more details about the PR to be added)