### PR TITLE
Fix: parse tol to scipy minimize.

### DIFF
--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -289,6 +289,7 @@ class ScipyMinimize(ScipyWrapper):
 
     res = osp.optimize.minimize(scipy_fun, jnp_to_onp(init_params, self.dtype),
                                 jac=True,
+                                tol=self.tol,
                                 bounds=bounds,
                                 method=self.method,
                                 options=self.options)

--- a/tests/scipy_wrappers_test.py
+++ b/tests/scipy_wrappers_test.py
@@ -113,7 +113,7 @@ class ScipyMinimizeTest(test_util.JaxoptTestCase):
     self.default_l2reg = float(self.n_samples)
 
     self.solver_kwargs = {'method': 'L-BFGS-B',
-                          'tol': 1e-3,
+                          'tol': 1e-5,
                           'options': {'maxiter': 500}}
 
     def logreg_fun(params, *args, **kwargs):


### PR DESCRIPTION
`tol` is not parsed to `scipy.optimize.minimize` in `ScipyMinimize`.