### PR TITLE
Corrected the implicit diff examples

### DIFF
--- a/examples/implicit_diff/lasso_implicit_diff.py
+++ b/examples/implicit_diff/lasso_implicit_diff.py
@@ -87,8 +87,8 @@ def main(argv):
   # Initialize solver.
   solver = OptaxSolver(opt=optax.adam(1e-2), fun=outer_objective, has_aux=True)
   theta = 1.0
-  state = solver.init_state(theta)
   init_w = jnp.zeros(X.shape[1])
+  state = solver.init_state(theta, init_inner=init_w, data=data)
 
   # Run outer loop.
   for _ in range(10):

--- a/examples/implicit_diff/ridge_reg_implicit_diff.py
+++ b/examples/implicit_diff/ridge_reg_implicit_diff.py
@@ -79,8 +79,8 @@ def main(argv):
   # Initialize solver.
   solver = OptaxSolver(opt=optax.adam(1e-2), fun=outer_objective, has_aux=True)
   theta = 1.0
-  state = solver.init_state(theta)
   init_w = jnp.zeros(X.shape[1])
+  state = solver.init_state(theta, init_inner=init_w, data=data)
 
   # Run outer loop.
   for _ in range(50):

--- a/examples/implicit_diff/sparse_coding.py
+++ b/examples/implicit_diff/sparse_coding.py
@@ -211,7 +211,11 @@ def _task_sparse_dictionary_learning(
   if optimizer is None:
     solver = ProximalGradient(fun=loss_fun, prox=prox_dic, has_aux=True)
     params = (dic_init, task_vars_init)
-    state = solver.init_state(params, None)
+    state = solver.init_state(
+      params,
+      None,
+      hyper_params=((data, regularization, elastic_penalty), task_params),
+    )
 
     for _ in range(maxiter):
       params, state = solver.update(
@@ -224,7 +228,10 @@ def _task_sparse_dictionary_learning(
   else:
     solver = OptaxSolver(opt=optimizer, fun=loss_fun, has_aux=True)
     params = (dic_init, task_vars_init)
-    state = solver.init_state(params)
+    state = solver.init_state(
+      params,
+      hyper_params=((data, regularization, elastic_penalty), task_params),
+    )
 
     for _ in range(maxiter):
       params, state = solver.update(


### PR DESCRIPTION
Currently on `main` the implicit diff examples have an error due to a missing state initialization (something noted [here](https://github.com/google/jaxopt/issues/235) as well although without a clear description).
For example for ridge regression:

```
Traceback (most recent call last):
  File "/home/zramzi/workspace/jaxopt/examples/implicit_diff/ridge_reg_implicit_diff.py", line 94, in <module>
    app.run(main)
  File "/home/zramzi/workspace/jaxopt/venv/lib/python3.9/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/home/zramzi/workspace/jaxopt/venv/lib/python3.9/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/home/zramzi/workspace/jaxopt/examples/implicit_diff/ridge_reg_implicit_diff.py", line 82, in main
    state = solver.init_state(theta)
  File "/home/zramzi/workspace/jaxopt/jaxopt/_src/optax_wrapper.py", line 109, in init_state
    _, aux = self.fun(init_params, *args, **kwargs)
TypeError: outer_objective() missing 2 required positional arguments: 'init_inner' and 'data'
```

This PR solves this problem.

Happy to also make them part of CI as was suggested by @mblondel .