### PR TITLE
Fix missing args,kwargs in resnet example

### DIFF
--- a/examples/deep_learning/flax_resnet.py
+++ b/examples/deep_learning/flax_resnet.py
@@ -211,7 +211,7 @@ def main(argv):
   start = datetime.now().replace(microsecond=0)
 
   # Run training loop.
-  state = solver.init_state(params)
+  state = solver.init_state(params, FLAGS.l2reg, next(test_ds), batch_stats)
   jitted_update = jax.jit(solver.update)
 
   for _ in range(solver.maxiter):


### PR DESCRIPTION
Fix bug introduced in https://github.com/google/jaxopt/commit/02bfdc2e2e9947611083b83b7bd1fc6783e3570d