### PR TITLE
Hot fix: corrected condition in lbfgs

### DIFF
--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -241,7 +241,7 @@ class LBFGS(base.IterativeSolver):
       print("error:", state.error)
     # We continue the optimization loop while the error tolerance is not met and,
     # either failed linesearch is disallowed or linesearch hasn't failed.
-    return (state.error > self.tol) & (~self.stop_if_linesearch_fails | ~state.failed_linesearch)
+    return (state.error > self.tol) & jnp.logical_or(not self.stop_if_linesearch_fails, ~state.failed_linesearch)
 
   def init_state(self,
                  init_params: Any,

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -247,13 +247,14 @@ class LbfgsTest(test_util.JaxoptTestCase):
     # Check optimality conditions.
     self.assertLessEqual(info.error, 1e-2)
 
-  def test_Rosenbrock(self):
+  @parameterized.product(implicit_diff=[True, False])
+  def test_Rosenbrock(self, implicit_diff):
     # optimize the Rosenbrock function.
     def fun(x, *args, **kwargs):
       return sum(100.0*(x[1:] - x[:-1]**2.0)**2.0 + (1 - x[:-1])**2.0)
 
     x0 = jnp.zeros(2)
-    lbfgs = LBFGS(fun=fun, tol=1e-3, maxiter=500)
+    lbfgs = LBFGS(fun=fun, tol=1e-3, maxiter=500, implicit_diff=implicit_diff)
     x, _ = lbfgs.run(x0)
 
     # the Rosenbrock function is zero at its minimum


### PR DESCRIPTION
The feature I had introduced in https://github.com/google/jaxopt/pull/323 was failing when the run function was jitted and was a no-op when not because of the following reason:

```python
 ~True == -2  # this is True
```

Therefore when jitted it was complaining about different types in a condition function, and when not jitted it was equivalent to always being False.

EDIT
------

Actually I am still running into an error when jitted, so will continue to investigate.

The gist of the error is `Abstract tracer value encountered where concrete value is expected`, basically doing `(not self.stop_if_linesearch_fails | ~state.failed_linesearch)` is not allowed because one is a `bool` and the other is an abstract value.