### PR TITLE
Added a new API allowing to warm start the inverse Hessian approximation in LBFGS

### DIFF
--- a/jaxopt/__init__.py
+++ b/jaxopt/__init__.py
@@ -21,6 +21,7 @@ from jaxopt import prox
 from jaxopt._src.anderson import AndersonAcceleration
 from jaxopt._src.anderson_wrapper import AndersonWrapper
 from jaxopt._src.armijo_sgd import ArmijoSGD
+from jaxopt._src.base import OptStep
 from jaxopt._src.backtracking_linesearch import BacktrackingLineSearch
 from jaxopt._src.bfgs import BFGS
 from jaxopt._src.bisection import Bisection

--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -185,7 +185,10 @@ class IterativeSolver(Solver):
   # search as an iterative solver, but for this reason and others
   # (automatic implicit diff) we should consider having it not be one.
   def _make_zero_step(self, init_params, state) -> OptStep:
-     return OptStep(params=init_params, state=state)
+    if isinstance(init_params, OptStep):
+      return OptStep(params=init_params.params, state=state)
+    else:
+      return OptStep(params=init_params, state=state)
 
   def _run(self,
            init_params: Any,
@@ -378,3 +381,4 @@ class IterativeLineSearch(IterativeSolver):
 
     return super()._run(init_stepsize, params, value, grad, descent_direction,
                         *args, **kwargs)
+

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -22,6 +22,7 @@ import numpy as onp
 
 from jaxopt._src.lbfgs import inv_hessian_product
 
+from jaxopt import OptStep
 from jaxopt import LBFGS
 from jaxopt import objective
 from jaxopt._src import test_util
@@ -261,6 +262,17 @@ class LbfgsTest(test_util.JaxoptTestCase):
 
     # the Rosenbrock function is zero at its minimum
     self.assertLessEqual(fun(x), 1e-2)
+
+  def test_warm_start_hessian_approx(self):
+    def fun(x, *args, **kwargs):
+      return sum(100.0*(x[1:] - x[:-1]**2.0)**2.0 + (1 - x[:-1])**2.0)
+
+    x0 = jnp.zeros(2)
+    lbfgs = LBFGS(fun=fun, tol=1e-3, maxiter=2, stepsize=1e-3)
+    x1, lbfgs_state = lbfgs.run(x0)
+
+    # warm start with the previous solution
+    x2, _ = lbfgs.run(OptStep(x1, lbfgs_state))
 
   @parameterized.product(out_dtype=[jnp.float32, jnp.float64])
   def test_correct_dtypes(self, out_dtype):


### PR DESCRIPTION
This fixes #351 .

@mblondel I couldn't use your suggestion of creating a new type of init `LBFGSInit` because the `init_params` variable is used for both `init_state` and `update`. Therefore I would have had to add case distinctions in the 2 functions which seemed unreasonable.
Rather I took the approach I saw in some other iterative solvers which was to add an extra keyword argument to `init_state`, `update` and `_value_and_grad_fun`.

I added a test to make sure that this runs, but I am not sure whether we need to add a test to make sure that it improves some cases. I also don't know whether we should test that differentiation is ok.