### PR TITLE
FIX: wrong latex in maml.ipynb

### DIFF
--- a/docs/notebooks/implicit_diff/maml.ipynb
+++ b/docs/notebooks/implicit_diff/maml.ipynb
@@ -228,6 +228,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -236,7 +237,7 @@
     "\n",
     "\n",
     "$$\n",
-    "\\text{argmin}_{\\theta} \\sum_{i=1}^K \\hat{\\mathcal{L_i}}(x_i(\\theta)) \\text{ subject to } x_i(\\theta) \\in \\text{argmin}_{x} {\\mathcal{L}}_i(x) + \\frac{\\lambda}{2}\\|x - \\theta\\|^2\\,,\n",
+    "\\text{argmin}_{\\theta} \\sum_{i=1}^K \\hat{\\mathcal{L}_i}(x_i(\\theta)) \\text{ subject to } x_i(\\theta) \\in \\text{argmin}_{x} {\\mathcal{L}}_i(x) + \\frac{\\lambda}{2}\\|x - \\theta\\|^2\\,,\n",
     "$$\n",
     "\n",
     "\n",
@@ -470,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.4 (main, Mar 31 2022, 03:38:35) [Clang 12.0.0 ]"
   },
   "vscode": {
    "interpreter": {

--- a/docs/notebooks/implicit_diff/maml.md
+++ b/docs/notebooks/implicit_diff/maml.md
@@ -163,7 +163,7 @@ Let $\mathcal{L_i}$ (resp. $\hat{\mathcal{L_i}}$) denote the the train set (resp
 
 
 $$
-\text{argmin}_{\theta} \sum_{i=1}^K \hat{\mathcal{L_i}}(x_i(\theta)) \text{ subject to } x_i(\theta) \in \text{argmin}_{x} {\mathcal{L}}_i(x) + \frac{\lambda}{2}\|x - \theta\|^2\,,
+\text{argmin}_{\theta} \sum_{i=1}^K \hat{\mathcal{L}_i}(x_i(\theta)) \text{ subject to } x_i(\theta) \in \text{argmin}_{x} {\mathcal{L}}_i(x) + \frac{\lambda}{2}\|x - \theta\|^2\,,
 $$
 
 


### PR DESCRIPTION
the underscore was insude the \mathcal command. It was actually rendering fine in mathjax, but it's wrong. I realized when copy pasting to latex.