### PR TITLE
Added possibility for line search methods to return a potential auxiliary value in their results

### DIFF
--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -196,14 +196,15 @@ class BFGS(base.IterativeSolver):
       # with line search
 
       if self.linesearch == "backtracking":
-        ls = BacktrackingLineSearch(fun=self._value_and_grad_fun,
+        ls = BacktrackingLineSearch(fun=self._value_and_grad_with_aux,
                                     value_and_grad=True,
                                     maxiter=self.maxls,
                                     decrease_factor=self.decrease_factor,
                                     max_stepsize=self.max_stepsize,
                                     condition=self.condition,
                                     jit=self.jit,
-                                    unroll=self.unroll)
+                                    unroll=self.unroll,
+                                    has_aux=True)
         init_stepsize = jnp.where(state.stepsize <= self.min_stepsize,
                                   # If stepsize became too small, we restart it.
                                   self.max_stepsize,
@@ -214,6 +215,7 @@ class BFGS(base.IterativeSolver):
                                         descent_direction,
                                         *args, **kwargs)
         new_value = ls_state.value
+        new_aux = ls_state.aux
         new_params = ls_state.params
         new_grad = ls_state.grad
 
@@ -221,9 +223,10 @@ class BFGS(base.IterativeSolver):
         ls_state = zoom_linesearch(f=self._value_and_grad_with_aux,
                                    xk=params, pk=descent_direction,
                                    old_fval=value, gfk=grad, maxiter=self.maxls,
-                                   value_and_grad=True, has_aux=True,
+                                   value_and_grad=True, has_aux=True, aux=aux,
                                    args=args, kwargs=kwargs)
         new_value = ls_state.f_k
+        new_aux = ls_state.aux
         new_stepsize = ls_state.a_k
         new_grad = ls_state.g_k
         # FIXME: zoom_linesearch currently doesn't return new_params
@@ -243,8 +246,7 @@ class BFGS(base.IterativeSolver):
 
       new_params = tree_add_scalar_mul(params, new_stepsize, descent_direction)
       # FIXME: this requires a second function call per iteration.
-      new_value, new_grad = self._value_and_grad_fun(new_params, *args,
-                                                     **kwargs)
+      (new_value, new_aux), new_grad = self._value_and_grad_with_aux(new_params, *args, **kwargs)
 
     s = tree_sub(new_params, params)
     y = tree_sub(new_grad, grad)
@@ -263,10 +265,7 @@ class BFGS(base.IterativeSolver):
                           stepsize=jnp.asarray(new_stepsize),
                           error=tree_l2_norm(new_grad),
                           H=new_H,
-                          # FIXME: we should return new_aux here but
-                          # BacktrackingLineSearch currently doesn't support
-                          # an aux.
-                          aux=aux)
+                          aux=new_aux)
 
     return base.OptStep(params=new_params, state=new_state)
 

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -140,6 +140,17 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
     self.assertTrue(res.failed)
     # s=30 will only be tried on the 6th iteration, so this won't converge
 
+  def test_aux_value(self):
+    def f(x):
+      return jnp.cos(jnp.sum(jnp.exp(-x)) ** 2), x
+
+    xk = jnp.ones(2)
+    pk = jnp.array([-0.5, -0.25])
+    res = zoom_linesearch(f, xk, pk, maxiter=100, has_aux=True)
+    new_stepsize = res.a_k
+    new_xk = xk + new_stepsize * pk
+    self.assertArraysEqual(res.aux, new_xk)
+
   def test_line_search(self):
 
     def f(x):


### PR DESCRIPTION
Linesearch methods affected : Backtracking linesearch and Zoom linesearch.

This was was also used in order to correct the way auxiliary values are handled in the BFGS, L-BFGS and Nonlinear CG solvers where these methods are used.

I still need to add tests on the matching between the auxiliary value and the parameters returned.
