### PR TITLE
Add inverse hessian approximation to the returned state

### DIFF
--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -36,6 +36,7 @@ from typing import Union
 import jax
 import jax.numpy as jnp
 import jax.tree_util as tree_util
+from jax.config import config
 
 from jaxopt._src import base
 from jaxopt._src import implicit_diff as idf
@@ -66,7 +67,7 @@ class LbfgsInvHessProductPyTree(LbfgsInvHessProduct):
     if sk.shape != yk.shape or sk.ndim != 2:
       raise ValueError('sk and yk must have matching shape, (n_corrs, n)')
     n_corrs, n = sk.shape
-    self.dtype = jnp.float64
+    self.dtype = jnp.float64 if config.jax_enable_x64 is True else jnp.float32
     self.shape = (n, n)
     self.sk = sk
     self.yk = yk

--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -41,9 +41,50 @@ from jaxopt._src import base
 from jaxopt._src import implicit_diff as idf
 from jaxopt._src import projection
 from jaxopt._src.tree_util import tree_sub
+from jax.tree_util import register_pytree_node_class
 
 import numpy as onp
 import scipy as osp
+from scipy.optimize import LbfgsInvHessProduct
+
+
+@register_pytree_node_class
+class LbfgsInvHessProductPyTree(LbfgsInvHessProduct):
+  """
+  Registers the LbfgsInvHessProduct object as a PyTree.
+  This object is typically returned by the L-BFSG-B optimizer to efficiently 
+  store the inverse of the Hessian matrix evaluated at the best-fit parameters. 
+  """
+
+  def __init__(self, sk, yk):
+    """
+    Construct the operator.
+    This is the same constructor as the original LbfgsInvHessProduct class,
+    except that numpy has been replaced by jax.numpy and no call to the 
+    numpy.ndarray constuctor is performed.
+    """
+    if sk.shape != yk.shape or sk.ndim != 2:
+      raise ValueError('sk and yk must have matching shape, (n_corrs, n)')
+    n_corrs, n = sk.shape
+    self.dtype = jnp.float64
+    self.shape = (n, n)
+    self.sk = sk
+    self.yk = yk
+    self.n_corrs = n_corrs
+    self.rho = 1 / jnp.einsum('ij,ij->i', sk, yk)
+
+
+  def __repr__(self):
+      return "LbfgsInvHessProduct(sk={}, yk={})".format(self.sk, self.yk)
+
+  def tree_flatten(self):
+      children = (self.sk, self.yk)
+      aux_data = None
+      return (children, aux_data)
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):
+      return cls(*children)
 
 
 class ScipyMinimizeInfo(NamedTuple):
@@ -52,6 +93,7 @@ class ScipyMinimizeInfo(NamedTuple):
   success: bool
   status: int
   iter_num: int
+  hess_inv: Optional[Union[jnp.ndarray, LbfgsInvHessProductPyTree]]
 
 
 class ScipyRootInfo(NamedTuple):
@@ -312,10 +354,21 @@ class ScipyMinimize(ScipyWrapper):
                                 options=self.options)
 
     params = tree_util.tree_map(jnp.asarray, onp_to_jnp(res.x))
+
+    if hasattr(res, 'hess_inv'):
+      if isinstance(res.hess_inv, osp.optimize.LbfgsInvHessProduct):
+        hess_inv = LbfgsInvHessProductPyTree(res.hess_inv.sk,
+                                             res.hess_inv.yk)
+      elif isinstance(res.hess_inv, onp.ndarray):
+        hess_inv = jnp.asarray(res.hess_inv)
+    else:
+      hess_inv = None
+        
     info = ScipyMinimizeInfo(fun_val=jnp.asarray(res.fun),
                              success=res.success,
                              status=res.status,
-                             iter_num=res.nit)
+                             iter_num=res.nit,
+                             hess_inv=hess_inv)
     return base.OptStep(params, info)
 
   def run(self,


### PR DESCRIPTION
The `state` returned after running `ScipyMinimize` now contains the approximated inverse Hessian matrix (if the optimizer supports it, e.g. `'BFGS'`). The inverse Hessian matrix gives an approximation of the covariance matrix.
A small test has been added to check against original scipy. 
The goal is to solve issue #381. 