### PR TITLE
Added Option to Reduce Variance of Jacobian of Perturbed Argmax

### DIFF
--- a/jaxopt/_src/perturbations.py
+++ b/jaxopt/_src/perturbations.py
@@ -21,9 +21,6 @@ import jax.numpy as jnp
 class Normal:
   """Normal distribution."""
 
-  def __init__(self):
-      self.has_zero_mean = True
-
   def sample(self,
              seed: jax.random.PRNGKey,
              sample_shape: Tuple[int]) -> jax.Array:
@@ -35,9 +32,6 @@ class Normal:
 
 class Gumbel:
   """Gumbel distribution."""
-
-  def __init__(self):
-      self.has_zero_mean = False
 
   def sample(self,
              seed: jax.random.PRNGKey,
@@ -64,8 +58,7 @@ def make_perturbed_argmax(argmax_fun: Callable[[jax.Array], jax.Array],
     noise: a distribution object that must implement a sample function and a
       log-pdf of the desired distribution, similar to the examples above.
       Default is Gumbel distribution.
-    reduce_variance : If noise distribution has zero mean use an alternative
-      estimator for the Jacobian which is more stable for small values of sigma.
+    reduce_variance : Option to reduce variance of gradients.
       Default is False.
 
   Returns:
@@ -130,11 +123,11 @@ def make_perturbed_argmax(argmax_fun: Callable[[jax.Array], jax.Array],
         jnp.reshape(tangent, (-1,)))
     return jnp.reshape(tangent_flat, inputs.shape)
 
-  # If noise has zero mean then give option for variance reduction. 
-  if reduce_variance and noise.has_zero_mean:
+  if reduce_variance:
       forward_pert.defjvps(pert_jvp_reduce_variance, None)
   else:
       forward_pert.defjvps(pert_jvp, None)
+
   return forward_pert
 
 

--- a/jaxopt/_src/perturbations.py
+++ b/jaxopt/_src/perturbations.py
@@ -58,11 +58,8 @@ def make_perturbed_argmax(argmax_fun: Callable[[jax.Array], jax.Array],
     noise: a distribution object that must implement a sample function and a
       log-pdf of the desired distribution, similar to the examples above.
       Default is Gumbel distribution.
-    control_variate : Subtract a control variate (the unperturbed argmax) from
-      the perturbed argmax in the monte-carlo estimate of the jacobian. For
-      low values of sigma, this prevents the jacobian for exploding and can
-      reduce variance.
-      Default is False.
+    control_variate : Boolean indicating whether a control variate is used in
+      the Monte-carlo estimate of the Jacobian.
 
   Returns:
     A function with the same signature (and an rng) that can be differentiated.

--- a/jaxopt/_src/perturbations.py
+++ b/jaxopt/_src/perturbations.py
@@ -59,7 +59,7 @@ def make_perturbed_argmax(argmax_fun: Callable[[jax.Array], jax.Array],
       log-pdf of the desired distribution, similar to the examples above.
       Default is Gumbel distribution.
     control_variate : Boolean indicating whether a control variate is used in
-      the Monte-carlo estimate of the Jacobian.
+      the Monte-Carlo estimate of the Jacobian.
 
   Returns:
     A function with the same signature (and an rng) that can be differentiated.

--- a/tests/perturbations_test.py
+++ b/tests/perturbations_test.py
@@ -100,7 +100,8 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         argmax_fun=one_hot_argmax,
         num_samples=self.num_samples,
         sigma=self.sigma,
-        noise=perturbations.Gumbel()))
+        noise=perturbations.Gumbel(),
+        control_variate=True))
 
 
     rngs_batch = jax.random.split(self.rng, 2)
@@ -124,7 +125,8 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         argmax_fun=one_hot_argmax,
         num_samples=self.num_samples,
         sigma=self.sigma,
-        noise=perturbations.Gumbel()))
+        noise=perturbations.Gumbel(),
+        control_variate=True))
 
     rngs_batch = jax.random.split(self.rng, 2)
     pert_argmax_repeat = jax.vmap(pert_argmax_fun)(theta_batch_repeat,
@@ -185,7 +187,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         num_samples=self.num_samples,
         sigma=0.01,
         noise=perturbations.Gumbel(),
-        reduce_variance=True))
+        control_variate=True))
 
     rng, _  = jax.random.split(self.rng, 2)
     jac_softmax = jax.jacfwd(jax.nn.softmax)
@@ -244,7 +246,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         num_samples=10000,
         sigma=self.sigma,
         noise=perturbations.Normal(),
-        reduce_variance=True)))
+        control_variate=True)))
 
 
 
@@ -297,7 +299,8 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         argmax_fun=ranks,
         num_samples=self.num_samples,
         sigma=1e-9,
-        noise=perturbations.Normal()))
+        noise=perturbations.Normal(),
+        control_variate=True))
 
     pert_ranks_small_sigma = pert_ranks_fn_small_sigma(theta, self.rng)
     pert_ranks_small_sigma_rv = pert_ranks_fn_small_sigma_rv(theta, self.rng)

--- a/tests/perturbations_test.py
+++ b/tests/perturbations_test.py
@@ -95,7 +95,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         sigma=self.sigma,
         noise=perturbations.Gumbel()))
 
-    # same as pert_argmax_fun but with reduced variance
+    # same as pert_argmax_fun with control variate 
     pert_argmax_fun_rv = jax.jit(perturbations.make_perturbed_argmax(
         argmax_fun=one_hot_argmax,
         num_samples=self.num_samples,
@@ -120,7 +120,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         sigma=self.sigma,
         noise=perturbations.Gumbel()))
 
-    # same as pert_argmax_fun but with reduced variance
+    # same as pert_argmax_fun but with control variate 
     pert_argmax_fun_rv = jax.jit(perturbations.make_perturbed_argmax(
         argmax_fun=one_hot_argmax,
         num_samples=self.num_samples,
@@ -150,7 +150,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
       pert_argmax_batch = jax.vmap(pert_argmax_fun)(theta_batch, rngs_batch)
       return jnp.mean(square_norm_fun(pert_argmax_batch))
 
-    # with reduced variance
+    # with control variate 
     def square_loss_rv(theta_batch, rng):
       batch_size = theta_batch.shape[0]
       rngs_batch = jax.random.split(rng, batch_size)
@@ -170,7 +170,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
     self.assertArraysAllClose(grad_pert_rv, grad_soft, atol=1e-1)
 
     """
-    Test ensuring that for small sigma, variance reduction indeed leads
+    Test ensuring that for small sigma, control variate indeed leads
     to a Jacobian that is closter to that of the softmax.
     """
     sigma = 0.01
@@ -181,7 +181,7 @@ class PerturbationsArgmaxTest(test_util.JaxoptTestCase):
         sigma=0.01,
         noise=perturbations.Gumbel()))
 
-    # same as pert_argmax_fun but with reduced variance
+    # same as pert_argmax_fun but with control variate 
     pert_argmax_fun_rv = jax.jit(perturbations.make_perturbed_argmax(
         argmax_fun=one_hot_argmax,
         num_samples=self.num_samples,


### PR DESCRIPTION
The jacobian of the perturbed argmax [Proposition 3.1 Berthet et al.](https://arxiv.org/pdf/2002.08676.pdf)  explodes as sigma tends to 0. If the noise distribution is has zero mean (such as `perturbations.Normal`), then it is possible to avoid this problem by replacing y(theta + sigma Z) with y(theta + sigma Z)  - y(theta) in the monte-carlo estimator, as described in [Le Lidec 2021](https://proceedings.neurips.cc/paper/2021/file/ab233b682ec355648e7891e66c54191b-Paper.pdf) and [Bach 2023](https://www.di.ens.fr/~fbach/ltfp_book.pdf).

This PR implements this minor change by adding a boolean variable `has_zero_mean` to the noise distributions in `perturbations` as well as adding another optional boolean argument to `perturbations.make_perturbed_argmax`, called `reduce_variance`. If both of these booleans are true, then the Jacobian is instead calculated in the above manner, with reduced variance.

I have provided [an example notebook](https://github.com/LawrenceMMStewart/make_perturbed_argmax-variance-reduction/blob/main/Jaxopt-Variance-Reduction.ipynb), which demonstrates the functionality of the PR on a simple differentiable ranking examples similar to that of the existing jaxopt example gallery. 

This implementation can be further optimized. Instead of calculating `output = argmax_fun(inputs)` in the function `pert_jvp_reduce_variance`, we can use the fact that this value was already recorded in the forward pass by the function `forward_pert`. However, I am unsure how one goes about accessing the output of a forward pass in a `custom_jvp` function.



