### PR TITLE
fix cond in zoom linesearch for non-jittable case, moved if_else_cond…

### DIFF
--- a/jaxopt/_src/backtracking_linesearch.py
+++ b/jaxopt/_src/backtracking_linesearch.py
@@ -99,8 +99,8 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
       value: Optional[float] = None,
       grad: Optional[Any] = None,
       descent_direction: Optional[Any] = None,
-      fun_args: list[Any] = [],
-      fun_kwargs: dict[str, Any] = {},
+      fun_args: list = [],
+      fun_kwargs: dict = {},
   ) -> BacktrackingLineSearchState:
     """Initialize the line search state.
 

--- a/jaxopt/_src/cond.py
+++ b/jaxopt/_src/cond.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Branching utilities."""
+
+import jax
+
+def cond(cond, if_fun, else_fun, *operands, jit=True):
+  """Wrapper to avoid having the condition to be compiled if not wanted."""
+  if not jit:
+    with jax.disable_jit():
+      return jax.lax.cond(cond, if_fun, else_fun, *operands)
+  return jax.lax.cond(cond, if_fun, else_fun, *operands)

--- a/jaxopt/cond.py
+++ b/jaxopt/cond.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jaxopt._src.cond import cond

--- a/tests/cond_test.py
+++ b/tests/cond_test.py
@@ -1,0 +1,45 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+import jax.numpy as jnp
+import numpy as onp
+
+from jaxopt._src.cond import cond
+from jaxopt._src import test_util
+
+
+class CondTest(test_util.JaxoptTestCase):
+
+  @parameterized.product(jit=[False, True])
+  def test_cond(self, jit):
+    def true_fun(x):
+      return x
+    def false_fun(x):
+      return jnp.zeros_like(x)
+        
+    def my_relu(x):
+      return cond(jnp.sum(x)>0, true_fun, false_fun, x, jit=jit)
+
+    if jit:
+      x = onp.array([1.])
+    else:
+      x = jnp.array([1.])
+    self.assertEqual(jax.nn.relu(x), my_relu(x))
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -379,6 +379,18 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
       ):
         self.assertEqual(getattr(state, name).dtype, out_dtype)
 
+  @parameterized.product(jit=[False, True])
+  def test_non_jittable(self, jit):
+    def fun(x):
+      return -onp.sin(10 * x), -10 * onp.cos(10 * x)
+    x = 1.
+    def run_ls():
+      ls = ZoomLineSearch(fun, value_and_grad=True, jit=jit)
+      ls.run(init_stepsize=1.0, params=x)
+    if jit:
+      self.assertRaises(jax.errors.TracerArrayConversionError, run_ls)
+    else:
+      run_ls()
 
 if __name__ == "__main__":
   # Uncomment the line below in order to run in float64.


### PR DESCRIPTION
Prevent jitting in zoom linesearch due to lax.cond see #444 for context. Added test.
Moved utilitary ifelse_cond from osqp.py into cond.py