### PR TITLE
Adding num function/grad/prox/ls eval in solvers

### DIFF
--- a/jaxopt/_src/anderson.py
+++ b/jaxopt/_src/anderson.py
@@ -108,6 +108,8 @@ class AndersonState(NamedTuple):
   residual_gram: jnp.array
   aux: Any
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class AndersonAcceleration(base.IterativeSolver):
@@ -185,7 +187,8 @@ class AndersonAcceleration(base.IterativeSolver):
                          params_history=params_history,
                          residuals_history=residuals_history,
                          residual_gram=residual_gram,
-                         aux=aux)
+                         aux=aux,
+                         num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,
@@ -241,7 +244,8 @@ class AndersonAcceleration(base.IterativeSolver):
                                params_history=params_history,
                                residuals_history=residuals_history,
                                residual_gram=residual_gram,
-                               aux=aux)
+                               aux=aux,
+                               num_fun_eval=state.num_fun_eval+1)
 
     return base.OptStep(params=next_params, state=next_state)
 
@@ -253,7 +257,7 @@ class AndersonAcceleration(base.IterativeSolver):
   def __post_init__(self):
     if self.history_size < 2:
       raise ValueError("history_size should be greater or equal to 2.")
-    
+
     if self.has_aux:
       fun_ = self.fixed_point_fun
     else:

--- a/jaxopt/_src/anderson.py
+++ b/jaxopt/_src/anderson.py
@@ -106,9 +106,9 @@ class AndersonState(NamedTuple):
   params_history: Any
   residuals_history: Any
   residual_gram: jnp.array
-  aux: Any
+  aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
 
 
 @dataclass(eq=False)

--- a/jaxopt/_src/armijo_sgd.py
+++ b/jaxopt/_src/armijo_sgd.py
@@ -72,6 +72,9 @@ def armijo_line_search(fun_with_aux, unroll, jit,
     next_params: params after gradient step
     f_next: loss after gradient step
   """
+  # FIXME: (zramzi) this should return the number of iterations,
+  # the number of function and gradient calls to have
+  # these values available down the line.
   next_params = tree_add_scalar_mul(params, -stepsize, grad)
   f_next, _ = fun_with_aux(next_params, *args, **kwargs)
   grad_sqnorm = tree_l2_norm(grad, squared=True)

--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -44,6 +44,7 @@ from jaxopt import tree_util
 AutoOrBoolean = Union[str, bool]
 ArrayPair = Tuple[jnp.ndarray, jnp.ndarray]
 
+NUM_EVAL_DTYPE = 'int32'
 
 class OptStep(NamedTuple):
   params: Any
@@ -55,8 +56,6 @@ class KKTSolution(NamedTuple):
   dual_eq: Optional[Any] = None
   dual_ineq: Optional[Any] = None
 
-
-NUM_EVAL_DTYPE = jnp.int32
 
 # pylint: disable=g-bare-generic
 def _add_aux_to_value_and_grad(value_and_grad: Callable) -> Callable:

--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -56,6 +56,8 @@ class KKTSolution(NamedTuple):
   dual_ineq: Optional[Any] = None
 
 
+NUM_EVAL_DTYPE = jnp.int32
+
 # pylint: disable=g-bare-generic
 def _add_aux_to_value_and_grad(value_and_grad: Callable) -> Callable:
   def value_and_grad_with_aux(*a, **kw):

--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -56,9 +56,9 @@ class BfgsState(NamedTuple):
   H: jnp.ndarray
   aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
+  num_linesearch_iter: int = 0
 
 
 @dataclass(eq=False)
@@ -169,7 +169,9 @@ class BFGS(base.IterativeSolver):
                      H=jnp.eye(len(flat_init_params), dtype=dtype),
                      aux=aux,
                      num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
-                     num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
+                     num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+                     num_linesearch_iter=jnp.asarray(0, base.NUM_EVAL_DTYPE)
+                     )
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -56,6 +56,10 @@ class BfgsState(NamedTuple):
   H: jnp.ndarray
   aux: Optional[Any] = None
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class BFGS(base.IterativeSolver):
@@ -163,7 +167,9 @@ class BFGS(base.IterativeSolver):
                      stepsize=jnp.asarray(self.max_stepsize, dtype=dtype),
                      error=jnp.asarray(jnp.inf, dtype=dtype),
                      H=jnp.eye(len(flat_init_params), dtype=dtype),
-                     aux=aux)
+                     aux=aux,
+                     num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+                     num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,
@@ -212,6 +218,9 @@ class BFGS(base.IterativeSolver):
       new_value = ls_state.value
       new_grad = ls_state.grad
       new_aux = ls_state.aux
+      new_num_linesearch_iter = state.num_linesearch_iter + ls_state.iter_num
+      new_num_grad_eval = state.num_grad_eval + ls_state.num_grad_eval
+      new_num_fun_eval = state.num_fun_eval + ls_state.num_fun_eval
     else:
       if isinstance(self.stepsize, Callable):
         new_stepsize = self.stepsize(state.iter_num)
@@ -220,6 +229,9 @@ class BFGS(base.IterativeSolver):
 
       new_params = tree_add_scalar_mul(params, new_stepsize, descent_direction)
       (new_value, new_aux), new_grad = self._value_and_grad_with_aux(new_params, *args, **kwargs)
+      new_num_grad_eval = state.num_grad_eval + 1
+      new_num_fun_eval = state.num_fun_eval + 1
+      new_num_linesearch_iter = state.num_linesearch_iter
 
     s = tree_sub(new_params, params)
     y = tree_sub(new_grad, grad)
@@ -240,7 +252,10 @@ class BFGS(base.IterativeSolver):
                           stepsize=jnp.asarray(new_stepsize),
                           error=jnp.asarray(error, dtype=dtype),
                           H=new_H,
-                          aux=new_aux)
+                          aux=new_aux,
+                          num_grad_eval=new_num_grad_eval,
+                          num_fun_eval=new_num_fun_eval,
+                          num_linesearch_iter=new_num_linesearch_iter)
 
     return base.OptStep(params=new_params, state=new_state)
 

--- a/jaxopt/_src/bisection.py
+++ b/jaxopt/_src/bisection.py
@@ -38,7 +38,7 @@ class BisectionState(NamedTuple):
   sign: int
   aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
 
 
 @dataclass(eq=False)

--- a/jaxopt/_src/bisection.py
+++ b/jaxopt/_src/bisection.py
@@ -38,6 +38,8 @@ class BisectionState(NamedTuple):
   sign: int
   aux: Optional[Any] = None
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class Bisection(base.IterativeSolver):
@@ -111,7 +113,8 @@ class Bisection(base.IterativeSolver):
                           value=jnp.asarray(jnp.inf),
                           error=jnp.asarray(jnp.inf),
                           low=lower, high=upper,
-                          sign=jnp.asarray(sign))
+                          sign=jnp.asarray(sign),
+                          num_fun_eval=jnp.array(2, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params,
@@ -146,7 +149,8 @@ class Bisection(base.IterativeSolver):
                            low=low,
                            high=high,
                            sign=state.sign,
-                           aux=aux)
+                           aux=aux,
+                           num_fun_eval=state.num_fun_eval + 1)
 
     return base.OptStep(params=params, state=state)
 

--- a/jaxopt/_src/block_cd.py
+++ b/jaxopt/_src/block_cd.py
@@ -41,9 +41,9 @@ class BlockCDState(NamedTuple):
   predictions: jnp.ndarray
   subfun_g: jnp.ndarray
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_prox_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_prox_eval: int = 0
+  num_grad_eval: int = 0
 
 
 @dataclass(eq=False)
@@ -105,7 +105,9 @@ class BlockCoordinateDescent(base.IterativeSolver):
                         subfun_g=subfun_g,
                         error=jnp.asarray(jnp.inf),
                         num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
-                        num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
+                        num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE), 
+                        num_prox_eval=jnp.array(0, base.NUM_EVAL_DTYPE)
+                        )
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/broyden.py
+++ b/jaxopt/_src/broyden.py
@@ -119,8 +119,8 @@ class BroydenState(NamedTuple):
   aux: Optional[Any] = None
   failed_linesearch: bool = False
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_linesearch_iter: int = 0
 
 
 @dataclass(eq=False)
@@ -261,7 +261,9 @@ class Broyden(base.IterativeSolver):
                         **state_kwargs,
                         aux=aux,
                         failed_linesearch=jnp.asarray(False),
-                        num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
+                        num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE), 
+                        num_linesearch_iter=jnp.array(0, base.NUM_EVAL_DTYPE)
+                        )
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/fixed_point_iteration.py
+++ b/jaxopt/_src/fixed_point_iteration.py
@@ -37,9 +37,8 @@ class FixedPointState(NamedTuple):
   """
   iter_num: int
   error: float
-  aux: Any
-
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  aux: Optional[Any] = None
+  num_fun_eval: int = 0
 
 
 @dataclass(eq=False)
@@ -90,7 +89,9 @@ class FixedPointIteration(base.IterativeSolver):
     """
     return FixedPointState(iter_num=jnp.asarray(0),
                            error=jnp.asarray(jnp.inf),
-                           aux=None)
+                           aux=None, 
+                           num_fun_eval=jnp.asarray(0, base.NUM_EVAL_DTYPE)
+                           )
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/fixed_point_iteration.py
+++ b/jaxopt/_src/fixed_point_iteration.py
@@ -39,6 +39,8 @@ class FixedPointState(NamedTuple):
   error: float
   aux: Any
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class FixedPointIteration(base.IterativeSolver):
@@ -110,7 +112,8 @@ class FixedPointIteration(base.IterativeSolver):
     error = tree_l2_norm(tree_sub(next_params, params))
     next_state = FixedPointState(iter_num=state.iter_num + 1,
                                  error=error,
-                                 aux=aux)
+                                 aux=aux,
+                                 num_fun_eval=state.num_fun_eval + 1)
     return base.OptStep(params=next_params, state=next_state)
 
   def optimality_fun(self, params, *args, **kwargs):

--- a/jaxopt/_src/hager_zhang_linesearch.py
+++ b/jaxopt/_src/hager_zhang_linesearch.py
@@ -56,6 +56,9 @@ class HagerZhangLineSearchState(NamedTuple):
   failed: bool
   aux: Optional[Any] = None
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class HagerZhangLineSearch(base.IterativeLineSearch):
@@ -159,11 +162,11 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     # the left end point is equal to within tolerance of the initial value.
 
     def cond_fn(state):
-      done, failed, low, middle, high, _, _ = state
+      done, failed, low, middle, high, *_ = state
       return jnp.any((middle < high) & (middle > low) & ~done & ~failed)
 
     def body_fn(state):
-      done, failed, low, middle, high, value_middle, grad_middle = state
+      done, failed, low, middle, high, value_middle, grad_middle, it = state
       # Correspond to U1 in the paper.
       update_right_endpoint = grad_middle >= 0.
       new_high = jnp.where(~done & update_right_endpoint, middle, high)
@@ -195,9 +198,10 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
               new_middle,
               new_high,
               new_value_middle,
-              new_grad_middle)
+              new_grad_middle,
+              it + 1)
 
-    _, failed, final_low, _, final_high, _, _ = jax.lax.while_loop(
+    _, failed, final_low, _, final_high, _, _, nit = jax.lax.while_loop(
         cond_fn,
         body_fn,
         ((middle >= high) | (middle <= low),
@@ -206,8 +210,10 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
          middle,
          high,
          value_middle,
-         grad_middle))
-    return failed, final_low, final_high
+         grad_middle,
+         0))
+    num_fun_grad_calls = nit + 1
+    return failed, final_low, final_high, num_fun_grad_calls
 
   def _secant(self, x, low, high, descent_direction, *args, **kwargs):
     _, dlow = self._value_and_grad_on_line(
@@ -223,25 +229,29 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     # Corresponds to the secant^2 routine in the paper.
 
     c = self._secant(x, low, high, descent_direction, *args, **kwargs)
-    failed, new_low, new_high = self._update(
+    num_fun_grad_calls = 2
+    failed, new_low, new_high, num_fun_grad_calls_update = self._update(
         x, low, high, c, approx_wolfe_threshold_value,
         descent_direction, args, kwargs)
+    num_fun_grad_calls += num_fun_grad_calls_update
     on_left_boundary = jnp.equal(c, new_low)
     on_right_boundary = jnp.equal(c, new_high)
     c = jnp.where(on_right_boundary, self._secant(
         x, high, new_high, descent_direction, *args, **kwargs), c)
     c = jnp.where(on_left_boundary, self._secant(
         x, low, new_low, descent_direction, *args, **kwargs), c)
+    num_fun_grad_calls += 4
 
     def _reupdate():
       return self._update(
           x, new_low, new_high, c, approx_wolfe_threshold_value,
           descent_direction, args, kwargs)
 
-    failed, new_low, new_high = jax.lax.cond(
+    failed, new_low, new_high, num_fun_grad_calls_update = jax.lax.cond(
         on_left_boundary | on_right_boundary,
-        _reupdate, lambda: (failed, new_low, new_high))
-    return failed, new_low, new_high
+        _reupdate, lambda: (failed, new_low, new_high, 0))
+    num_fun_grad_calls += num_fun_grad_calls_update
+    return failed, new_low, new_high, num_fun_grad_calls
 
   def _bracket(
       self, x, c, approx_wolfe_threshold_value,
@@ -259,7 +269,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
        high,
        value_middle,
        grad_middle,
-       best_middle) = state
+       best_middle,
+       num_fun_grad_calls) = state
       # Correspond to B1 in the paper.
       update_right_endpoint = grad_middle >= 0.
       new_high = jnp.where(~done & update_right_endpoint, middle, high)
@@ -280,8 +291,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
             approx_wolfe_threshold_value,
             descent_direction, args, kwargs)
 
-      new_failed, new_low, new_high = jax.lax.cond(
-          reupdate, _update_interval, lambda: (failed, new_low, new_high))
+      new_failed, new_low, new_high, new_num_fun_grad_calls = jax.lax.cond(
+          reupdate, _update_interval, lambda: (failed, new_low, new_high, 0))
       failed = failed | new_failed
       done = done | reupdate
 
@@ -296,6 +307,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
 
       new_value_middle, new_grad_middle = self._value_and_grad_on_line(
           x, new_middle, descent_direction, *args, **kwargs)
+      new_num_fun_grad_calls += 1
+      num_fun_grad_calls += new_num_fun_grad_calls
 
       # Terminate on encountering NaNs to avoid an infinite loop.
       failed = failed  | _failed_nan(new_value_middle, new_grad_middle)
@@ -306,10 +319,12 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
               new_high,
               new_value_middle,
               new_grad_middle,
-              best_middle)
+              best_middle,
+              num_fun_grad_calls)
 
     value_c, grad_c = self._value_and_grad_on_line(
         x, c, descent_direction, *args, **kwargs)
+    num_fun_grad_calls = 1
 
     # We have failed if there is a NaN at the right endpoint, or the gradient is
     # NaN at the right endpoint (when there is a finite value).
@@ -317,7 +332,7 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     # If the right endpoint is -inf, then we are done as this is a minima.
     done = jnp.isneginf(value_c)
 
-    _, failed, final_low, _, final_high, _, _, _ = jax.lax.while_loop(
+    _, failed, final_low, _, final_high, _, _, _, new_num_fun_grad_calls = jax.lax.while_loop(
         cond_fn,
         body_fn,
         (done,
@@ -327,8 +342,10 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
          c,
          value_c,
          grad_c,
-         jnp.array(0.)))
-    return failed, final_low, final_high
+         jnp.array(0.),
+         0))
+    num_fun_grad_calls += new_num_fun_grad_calls
+    return failed, final_low, final_high, num_fun_grad_calls
 
   def init_state(
       self,
@@ -362,6 +379,12 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         )
       else:
         value, grad = self._value_and_grad_fun(params, *fun_args, **fun_kwargs)
+      num_fun_eval = 1
+      num_grad_eval = 1
+    else:
+      num_fun_eval = 0
+      num_grad_eval = 0
+
 
     if descent_direction is None:
       descent_direction = tree_scalar_mul(-1, grad)
@@ -370,7 +393,7 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         value + self.approximate_wolfe_threshold * jnp.abs(value))
 
     # Create initial interval.
-    failed, low, high = self._bracket(
+    failed, low, high, num_fun_grad_calls = self._bracket(
         params,
         jnp.ones_like(value),
         approx_wolfe_threshold_value,
@@ -378,12 +401,16 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         *fun_args,
         **fun_kwargs
     )
+    num_fun_eval += num_fun_grad_calls
+    num_grad_eval += num_fun_grad_calls
 
     value_low, grad_low = self._value_and_grad_on_line(
         params, low, descent_direction, *fun_args, **fun_kwargs)
 
     value_high, grad_high = self._value_and_grad_on_line(
         params, high, descent_direction, *fun_args, **fun_kwargs)
+    num_fun_eval += 2
+    num_grad_eval +=  2
 
     best_point = jnp.where(value_low < value_high, low, high)
     gd_vdot_best_point = jnp.where(value_low < value_high, grad_low, grad_high)
@@ -409,7 +436,9 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         aux=None,  # we do not need to have aux in the initial state
         params=params,
         grad=grad,
-        failed=failed)
+        failed=failed,
+        num_fun_eval=jnp.array(num_fun_eval, base.NUM_EVAL_DTYPE),
+        num_grad_eval=jnp.array(num_grad_eval, base.NUM_EVAL_DTYPE))
 
   def update(
       self,
@@ -444,6 +473,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         )
       else:
         value, grad = self._value_and_grad_fun(params, *fun_args, **fun_kwargs)
+    new_num_fun_eval = state.num_fun_eval + 1
+    new_num_grad_eval = state.num_grad_eval + 1
 
     if descent_direction is None:
       descent_direction = tree_scalar_mul(-1, grad)
@@ -451,13 +482,15 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     approx_wolfe_threshold_value = (
         value + self.approximate_wolfe_threshold * jnp.abs(value))
 
-    failed, new_low, new_high = self._secant2(
+    failed, new_low, new_high, num_fun_grad_calls = self._secant2(
         params,
         state.low,
         state.high,
         approx_wolfe_threshold_value,
         descent_direction,
         *fun_args, **fun_kwargs)
+    new_num_fun_eval += num_fun_grad_calls
+    new_num_grad_eval += num_fun_grad_calls
 
     failed = state.failed | failed
 
@@ -470,10 +503,12 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
           params, new_low, new_high, c, approx_wolfe_threshold_value,
           descent_direction, fun_args, fun_kwargs)
 
-    failed, new_low, new_high = jax.lax.cond(
+    failed, new_low, new_high, num_fun_grad_calls = jax.lax.cond(
         ~state.done & ((new_high - new_low) >
                        (self.shrinkage_factor * (state.high - state.low))),
-        _reupdate, lambda: (failed, new_low, new_high))
+        _reupdate, lambda: (failed, new_low, new_high, 0))
+    new_num_fun_eval += num_fun_grad_calls
+    new_num_grad_eval += num_fun_grad_calls
 
     # Check wolfe and approximate wolfe conditions and update them.
 
@@ -481,6 +516,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         params, new_low, descent_direction, *fun_args, **fun_kwargs)
     value_high, grad_high = self._value_and_grad_on_line(
         params, new_high, descent_direction, *fun_args, **fun_kwargs)
+    new_num_fun_eval += 2
+    new_num_grad_eval += 2
 
     best_point = jnp.where(value_low < value_high, new_low, new_high)
     gd_vdot_best_point = jnp.where(value_low < value_high, grad_low, grad_high)
@@ -496,6 +533,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
       new_value, new_grad = self._value_and_grad_fun(
           new_params, *fun_args, **fun_kwargs)
       new_aux = None
+    new_num_fun_eval += 1
+    new_num_grad_eval += 1
 
     error = jnp.where(state.done, state.error,
                       self._satisfies_wolfe_and_approx_wolfe(
@@ -519,7 +558,9 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
         high=new_high,
         error=error,
         done=done,
-        failed=failed)
+        failed=failed,
+        num_fun_eval=new_num_fun_eval,
+        num_grad_eval=new_num_grad_eval)
 
     return base.LineSearchStep(stepsize=new_stepsize, state=new_state)
 

--- a/jaxopt/_src/hager_zhang_linesearch.py
+++ b/jaxopt/_src/hager_zhang_linesearch.py
@@ -56,8 +56,8 @@ class HagerZhangLineSearchState(NamedTuple):
   failed: bool
   aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
 
 
 @dataclass(eq=False)

--- a/jaxopt/_src/iterative_refinement.py
+++ b/jaxopt/_src/iterative_refinement.py
@@ -57,9 +57,9 @@ class IterativeRefinementState(NamedTuple):
   # TODO(lbethune): in the future return the state of the internal
   # solver (iter_num, error) as part of the current state.
 
-  num_matvec_eval: jnp.array = jnp.array(0)
-  num_matvec_bar_eval: jnp.array = jnp.array(0)
-  num_solve_eval: jnp.array = jnp.array(0)
+  num_matvec_eval: int = 0
+  num_matvec_bar_eval: int = 0
+  num_solve_eval: int = 0
 
 
 @dataclass(eq=False)
@@ -132,7 +132,11 @@ class IterativeRefinement(base.IterativeSolver):
       iter_num=jnp.asarray(0),
       error=jnp.asarray(jnp.inf),
       target_residuals=b,
-      init=init_params)
+      init=init_params, 
+      num_matvec_eval=jnp.asarray(0, base.NUM_EVAL_DTYPE),
+      num_matvec_bar_eval=jnp.asarray(0, base.NUM_EVAL_DTYPE),
+      num_solve_eval=jnp.asarray(0, base.NUM_EVAL_DTYPE)
+)
 
   def init_params(self,
                   A: Any,

--- a/jaxopt/_src/iterative_refinement.py
+++ b/jaxopt/_src/iterative_refinement.py
@@ -57,6 +57,10 @@ class IterativeRefinementState(NamedTuple):
   # TODO(lbethune): in the future return the state of the internal
   # solver (iter_num, error) as part of the current state.
 
+  num_matvec_eval: jnp.array = jnp.array(0)
+  num_matvec_bar_eval: jnp.array = jnp.array(0)
+  num_solve_eval: jnp.array = jnp.array(0)
+
 
 @dataclass(eq=False)
 class IterativeRefinement(base.IterativeSolver):
@@ -162,7 +166,10 @@ class IterativeRefinement(base.IterativeSolver):
       iter_num=state.iter_num+1,
       error=error,
       target_residuals=target_residuals,
-      init=self.init_params(A, b, A_bar))
+      init=self.init_params(A, b, A_bar),
+      num_matvec_eval=state.num_matvec_eval + 1,
+      num_matvec_bar_eval=state.num_matvec_bar_eval + 1,
+      num_solve_eval=state.num_solve_eval + 1)
 
     return base.OptStep(params, state)
 

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -136,9 +136,9 @@ class LbfgsState(NamedTuple):
   gamma: jnp.ndarray
   aux: Optional[Any] = None
   failed_linesearch: bool = False
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
+  num_linesearch_iter: int = 0
 
 
 @dataclass(eq=False)
@@ -282,7 +282,8 @@ class LBFGS(base.IterativeSolver):
                       aux=aux,
                       failed_linesearch=jnp.asarray(False),
                       num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
-                      num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
+                      num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+                      num_linesearch_iter=jnp.array(0, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -146,6 +146,9 @@ class LbfgsState(NamedTuple):
   gamma: jnp.ndarray
   aux: Optional[Any] = None
   failed_linesearch: bool = False
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
 
 
 @dataclass(eq=False)
@@ -287,7 +290,9 @@ class LBFGS(base.IterativeSolver):
                       error=jnp.asarray(jnp.inf, dtype=dtype),
                       **state_kwargs,
                       aux=aux,
-                      failed_linesearch=jnp.asarray(False))
+                      failed_linesearch=jnp.asarray(False),
+                      num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+                      num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,
@@ -345,6 +350,9 @@ class LBFGS(base.IterativeSolver):
       new_grad = ls_state.grad
       new_aux = ls_state.aux
       failed_linesearch = ls_state.failed
+      new_num_linesearch_iter = state.num_linesearch_iter + ls_state.iter_num
+      new_num_grad_eval = state.num_grad_eval + ls_state.num_grad_eval
+      new_num_fun_eval = state.num_fun_eval + ls_state.num_fun_eval
 
     else:
       if isinstance(self.stepsize, Callable):
@@ -356,6 +364,9 @@ class LBFGS(base.IterativeSolver):
       (new_value, new_aux), new_grad = self._value_and_grad_with_aux(
           new_params, *args, **kwargs
       )
+      new_num_grad_eval = state.num_grad_eval + 1
+      new_num_fun_eval = state.num_fun_eval + 1
+      new_num_linesearch_iter = state.num_linesearch_iter
       failed_linesearch = jnp.asarray(False)
     s = tree_sub(new_params, params)
     y = tree_sub(new_grad, grad)
@@ -384,7 +395,10 @@ class LBFGS(base.IterativeSolver):
                            rho_history=rho_history,
                            gamma=gamma,
                            aux=new_aux,
-                           failed_linesearch=failed_linesearch)
+                           failed_linesearch=failed_linesearch,
+                           num_grad_eval=new_num_grad_eval,
+                           num_fun_eval=new_num_fun_eval,
+                           num_linesearch_iter=new_num_linesearch_iter)
 
     return base.OptStep(params=new_params, state=new_state)
 

--- a/jaxopt/_src/lbfgsb.py
+++ b/jaxopt/_src/lbfgsb.py
@@ -217,9 +217,9 @@ class LbfgsbState(NamedTuple):
   aux: Optional[Any] = None
   failed_linesearch: bool = False
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
+  num_linesearch_iter: int = 0
 
 
 @dataclasses.dataclass(eq=False)
@@ -373,6 +373,7 @@ class LBFGSB(base.IterativeSolver):
         failed_linesearch=jnp.asarray(False),
         num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
         num_grad_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+        num_linesearch_iter=np.array(0, base.NUM_EVAL_DTYPE)
     )
 
   def update(

--- a/jaxopt/_src/mirror_descent.py
+++ b/jaxopt/_src/mirror_descent.py
@@ -39,9 +39,9 @@ class MirrorDescentState(NamedTuple):
   error: float
   aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_proj_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
+  num_proj_eval: int = 0
 
 
 @dataclass(eq=False)
@@ -139,7 +139,9 @@ class MirrorDescent(base.IterativeSolver):
     return MirrorDescentState(iter_num=jnp.asarray(0),
                               error=jnp.asarray(jnp.inf),
                               aux=aux,
-                              num_fun_eval=num_fun_eval)
+                              num_fun_eval=num_fun_eval,
+                              num_grad_eval=jnp.array(0, base.NUM_EVAL_DTYPE),
+                              num_proj_eval=jnp.array(0, base.NUM_EVAL_DTYPE))
 
   def _error(self, x, next_x, stepsize):
     diff_x = tree_sub(next_x, x)

--- a/jaxopt/_src/nonlinear_cg.py
+++ b/jaxopt/_src/nonlinear_cg.py
@@ -43,6 +43,10 @@ class NonlinearCGState(NamedTuple):
   descent_direction: Any
   aux: Optional[Any] = None
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclass(eq=False)
 class NonlinearCG(base.IterativeSolver):
@@ -154,7 +158,9 @@ class NonlinearCG(base.IterativeSolver):
                             value=value,
                             grad=grad,
                             descent_direction=tree_scalar_mul(-1.0, grad),
-                            aux=aux)
+                            aux=aux,
+                            num_fun_eval=jnp.asarray(1, base.NUM_EVAL_DTYPE),
+                            num_grad_eval=jnp.asarray(1, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,
@@ -206,6 +212,9 @@ class NonlinearCG(base.IterativeSolver):
     new_value = ls_state.value
     new_grad = ls_state.grad
     new_aux = ls_state.aux
+    new_num_fun_eval = state.num_fun_eval + ls_state.num_fun_eval
+    new_num_grad_eval = state.num_grad_eval + ls_state.num_grad_eval
+    new_num_linesearch_iter = state.num_linesearch_iter + ls_state.iter_num
 
     if self.method == "polak-ribiere":
       # See Numerical Optimization, second edition, equation (5.44).
@@ -239,7 +248,10 @@ class NonlinearCG(base.IterativeSolver):
                                  value=new_value,
                                  grad=new_grad,
                                  descent_direction=new_descent_direction,
-                                 aux=new_aux)
+                                 aux=new_aux,
+                                 num_fun_eval=new_num_fun_eval,
+                                 num_grad_eval=new_num_grad_eval,
+                                 num_linesearch_iter=new_num_linesearch_iter)
 
     return base.OptStep(params=new_params, state=new_state)
 

--- a/jaxopt/_src/nonlinear_cg.py
+++ b/jaxopt/_src/nonlinear_cg.py
@@ -43,9 +43,9 @@ class NonlinearCGState(NamedTuple):
   descent_direction: Any
   aux: Optional[Any] = None
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_linesearch_iter: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
+  num_linesearch_iter: int = 0
 
 
 @dataclass(eq=False)
@@ -160,7 +160,9 @@ class NonlinearCG(base.IterativeSolver):
                             descent_direction=tree_scalar_mul(-1.0, grad),
                             aux=aux,
                             num_fun_eval=jnp.asarray(1, base.NUM_EVAL_DTYPE),
-                            num_grad_eval=jnp.asarray(1, base.NUM_EVAL_DTYPE))
+                            num_grad_eval=jnp.asarray(1, base.NUM_EVAL_DTYPE),
+                            num_linesearch_iter=jnp.array(0, base.NUM_EVAL_DTYPE)
+                            )
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/polyak_sgd.py
+++ b/jaxopt/_src/polyak_sgd.py
@@ -43,8 +43,8 @@ class PolyakSGDState(NamedTuple):
   stepsize: float
   velocity: Optional[Any]
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_grad_eval: int = 0
 
 
 @dataclasses.dataclass(eq=False)
@@ -161,7 +161,8 @@ class PolyakSGD(base.StochasticSolver):
                           stepsize=jnp.asarray(1.0, dtype=params_dtype),
                           aux=aux,
                           velocity=velocity,
-                          num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
+                          num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE),
+                          num_grad_eval=jnp.array(0, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,

--- a/jaxopt/_src/polyak_sgd.py
+++ b/jaxopt/_src/polyak_sgd.py
@@ -43,6 +43,9 @@ class PolyakSGDState(NamedTuple):
   stepsize: float
   velocity: Optional[Any]
 
+  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_grad_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+
 
 @dataclasses.dataclass(eq=False)
 class PolyakSGD(base.StochasticSolver):
@@ -157,7 +160,8 @@ class PolyakSGD(base.StochasticSolver):
                           value=jnp.asarray(jnp.inf, dtype=value.dtype),
                           stepsize=jnp.asarray(1.0, dtype=params_dtype),
                           aux=aux,
-                          velocity=velocity)
+                          velocity=velocity,
+                          num_fun_eval=jnp.array(1, base.NUM_EVAL_DTYPE))
 
   def update(self,
              params: Any,
@@ -202,7 +206,9 @@ class PolyakSGD(base.StochasticSolver):
                                velocity=new_velocity,
                                value=jnp.asarray(value),
                                stepsize=jnp.asarray(stepsize, dtype=dtype),
-                               aux=aux)
+                               aux=aux,
+                               num_fun_eval=state.num_fun_eval + 1,
+                               num_grad_eval=state.num_grad_eval + 1)
     return base.OptStep(params=new_params, state=new_state)
 
   def optimality_fun(self, params, *args, **kwargs):

--- a/jaxopt/_src/scipy_wrappers.py
+++ b/jaxopt/_src/scipy_wrappers.py
@@ -93,9 +93,9 @@ class ScipyMinimizeInfo(NamedTuple):
   status: int
   iter_num: int
   hess_inv: Optional[Union[jnp.ndarray, LbfgsInvHessProductPyTree]]
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_jac_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
-  num_hess_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
+  num_jac_eval: int = 0
+  num_hess_eval: int = 0
 
 
 class ScipyRootInfo(NamedTuple):
@@ -105,7 +105,7 @@ class ScipyRootInfo(NamedTuple):
   status: int
   iter_num: int
 
-  num_fun_eval: jnp.array = jnp.array(0, base.NUM_EVAL_DTYPE)
+  num_fun_eval: int = 0
 
 
 class ScipyLeastSquaresInfo(NamedTuple):
@@ -360,9 +360,9 @@ class ScipyMinimize(ScipyWrapper):
       hess_inv = None
 
     try:
-      num_hess_eval = jnp.asarray(res.nhev)
+      num_hess_eval = jnp.asarray(res.nhev, base.NUM_EVAL_DTYPE)
     except AttributeError:
-      num_hess_eval = jnp.array(0)
+      num_hess_eval = jnp.array(0, base.NUM_EVAL_DTYPE)
 
     info = ScipyMinimizeInfo(fun_val=jnp.asarray(res.fun),
                              success=res.success,
@@ -678,8 +678,8 @@ class ScipyLeastSquares(ScipyWrapper):
                                  fun_val=jnp.asarray(res.fun),
                                  success=res.success,
                                  status=res.status,
-                                 num_fun_eval=res.nfev,
-                                 num_jac_eval=res.njev,
+                                 num_fun_eval=jnp.asarray(res.nfev, base.NUM_EVAL_DTYPE),
+                                 num_jac_eval=jnp.asarray(res.njev, base.NUM_EVAL_DTYPE),
                                  error=jnp.asarray(res.optimality))
     return base.OptStep(params, info)
 

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -354,8 +354,10 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
       _, state = ls.run(init_stepsize=1.0, params=xk, descent_direction=pk)
       for name in ("done", "interval_found", "failed"):
         self.assertEqual(getattr(state, name).dtype, jnp.bool_)
-      for name in ("iter_num", "num_fun_eval", "num_grad_eval", "fail_code"):
+      for name in ("iter_num", "fail_code"):
         self.assertEqual(getattr(state, name).dtype, jnp.int64)
+      for name in ("num_fun_eval", "num_grad_eval"):
+        self.assertEqual(getattr(state, name).dtype, jnp.int32)
       for name in (
           "params",
           "grad",


### PR DESCRIPTION
For now HZ-LS does not have the right elements in the state so it will fail in all solvers

Added num function/grad/ls eval in the following solvers:
- (L)-BFGS-(B): added num fun/grad/ls
- Anderson: added num fun
- Armijo SGD: for now armijo LS does not return the correct elements so difficult to do, esp. because the loops do not return the number of iterations done
- Bisection: added num fun
- BlockCD: added num fun/prox/grad
- Broyden: added num fun/ls
- FixedPointIteration: added num fun
- Gauss-Newton: not doable, because at some point linear solve does not return the number of iterations done. This comes down to `_cg_solve` returning only the final result.
- (Proximal/Projected)GradientDescent: the fista LS does not return the number of iterations done (same problem as Armijo)
- IterativeRefinement: added num matvec/matvec bar/solve
- LevenbergMarquardt: not sufficient info returned by the solver (+ extremely complex code)
- MirrorDescent: added num fun/grad/proj
- NonLinearCG: added num fun/grad/ls
- OptaxWrapper: I don't think we have this info in every optax state, which in any case can be looked up with the current API
- PolyakSGD: added num fun/grad
- ScipyWrapper(s): added num fun/jac/hess in scipy minimize, added num fun (and num iter) in scipy root