### PR TITLE
Extend convenience API for QP + doc

### DIFF
--- a/docs/quadratic_programming.rst
+++ b/docs/quadratic_programming.rst
@@ -10,61 +10,83 @@ The solver specificities are summarized in the table below.
 The best choice will depend on the usage.
 
 .. list-table:: Quadratic programming solvers
-   :widths: 45, 15, 20, 15, 15, 15, 22, 15
+   :widths: 45, 15, 20, 20, 15, 15, 15, 22, 15, 15
    :header-rows: 1
 
    * - Name
      - jit
+     - pytree
      - matvec
-     - fun
+     - quad. fun
      - precision
      - stability
      - speed
+     - derivative
      - input format
    * - :class:`jaxopt.EqualityConstrainedQP`
      - yes
      - yes
-     - no
+     - yes
+     - yes
      - ++
      - \+
      - +++
+     - implicit
      - (Q, c), (A, b)
    * - :class:`jaxopt.CvxpyQP`
      - no
      - no
      - no
+     - no
      - +++
      - +++
      - \+
+     - implicit
      - (Q, c), (A, b), (G, h)
    * - :class:`jaxopt.OSQP`
      - yes
      - yes
      - yes
+     - yes
      - \+
      - ++
      - ++
+     - implicit
      - (Q, c), (A, b), (G, h)
    * - :class:`jaxopt.BoxOSQP`
      - yes
      - yes
      - yes
+     - yes
      - \+
      - ++
      - ++
+     - both
      - (Q, c), A, (l, u)
+   * - :class:`jaxopt.BoxCDQP`
+     - yes
+     - no
+     - no
+     - no
+     - ++
+     - +++
+     - ++
+     - both
+     - (Q, c), (l, u)
 
 - *jit*: the algorithm can be used with jit or vmap, on GPU/TPU.
-- *matvec*: the input can be given as matvec instead of dense matrices.
-- *fun*: the algorithm can be used with quadratic polynomial fun.
+- *pytree*: the algorithm can be used with pytrees of matrices (see below).
+- *matvec*: the QP parameters can be given as matvec instead of dense matrices (see below).
+- *quad. fun*: the algorithm can be used with a quadratic function argument (see below).
 - *precision*: accuracy expected when the solver succeeds to converge.
 - *stability*: capacity to handle badly scaled problems and matrices with poor conditioning.
 - *speed*: typical speed on big instances to reach its maximum accuracy.
+- *derivative*: whether differentiation is supported only via implicit differentiation, or by both implicit differentiation and unrolling.
 - *input format*: see subsections below.
 
 
 This table is given as rule of thumb only; on some particular instances
-some solvers may behave unexpectedly better than others.
+some solvers may behave unexpectedly better (or worse!) than others.
 In case of difficulties, we suggest to test different combinations of
 algorithms, ``maxiter`` and ``tol`` values.
 
@@ -87,7 +109,8 @@ The problem takes the form:
 
     jaxopt.EqualityConstrainedQP
 
-This class is optimized for QPs with equality constraints only: it supports jit, pytrees and matvec.
+This class is optimized for QPs with equality constraints only: it supports jit, pytrees and matvec.  
+It is based on the KKT conditions of the problem.
 
 Example::
 
@@ -179,6 +202,9 @@ OSQP
 This solver is a pure JAX re-implementation of the OSQP algorithm.
 It is jittable, supports pytrees and matvecs, but the precision is usually
 lower than :class:`CvxpyQP` when run in float32 precision.
+It is meant as a drop-in replacement for :class:`CvxpyQP`, but it
+is a wrapper over :class:`BoxOSQP`.
+Hence we recommend to use :class:`BoxOSQP` to avoid a costly problem transformation.
 
 .. autosummary::
   :toctree: _autosummary
@@ -226,6 +252,7 @@ The problem takes the form:
 :class:`jaxopt.BoxOSQP` uses the same underlying solver as :class:`jaxopt.OSQP`
 but accepts problems in the above box-constrained format instead.  The bounds
 ``u`` (resp. ``l``) can be set to ``inf`` (resp. ``-inf``) if required.
+Equality can be enforced with ``l = u``.
 
 Example::
 
@@ -316,3 +343,196 @@ algorithms is *conjugate gradient*.  In JAXopt, this can be done as follows::
   sol = solve_cg(matvec, b=-c)
 
   print(sol)
+
+Pytree of matrices API
+----------------------
+
+Solvers :class:`EqualityConstrainedQP`, :class:`OSQP` and :class:`BoxOSQP` support
+the pytree of matrices API. It means that the matrices `Q`, `A`, `G` can be provided
+as block diagonal operator whose blocks are leaves of pytrees.
+This corresponds to separable problems that can be solved in parallel (one for each leaf).
+
+It offers several advantages:
+  * This model of parallelism succeeds even if all the problems have different shapes,
+    contrary to the `jax.vmap` API.
+  * This formulation is more efficient than a single big matrix, especially when
+    there are a lot of blocks, and when the blocks themselves are small.
+  * The tolerance is globally defined and shared by all the problems,
+    and the number of iterations is the same for all the problems. 
+
+We illustrate below the parallel solving of two problems with different shapes::
+
+  Q1 = jnp.array([[1.0, -0.5],
+                  [-0.5, 1.0]])
+  Q2 = jnp.array([[2.0]])
+  Q = {'problem1': Q1, 'problem2': Q2}
+
+  c1 = jnp.array([-0.4, 0.3])
+  c2 = jnp.array([0.1])
+  c = {'problem1': c1, 'problem2': c2}
+
+  a1 = jnp.array([[-0.5, 1.5]])
+  a2 = jnp.array([[10.0]])
+  A = {'problem1': a1, 'problem2': a2}
+
+  b1 = jnp.array([0.3])
+  b2 = jnp.array([5.0])
+  b = {'problem1': b1, 'problem2': b2}
+
+  qp = EqualityConstrainedQP(tol=1e-3)
+  hyperparams = dict(params_obj=(Q, c), params_eq=(A, b))
+  # Solve the two problems in parallel with a single call.
+  sol = qp.run(**hyperparams).params
+  print(sol.primal['problem1'], sol.primal['problem2'])
+
+Matvec API
+----------
+
+Solvers :class:`EqualityConstrainedQP`, :class:`OSQP` and :class:`BoxOSQP` support the matvec API.
+It means that the user can provide a function ``matvec`` that computes the matrix-vector product,
+either in the objective `x -> Qx` or in the constraints `x -> Ax`, `x -> Gx`.  
+  
+It offers several advantages:
+  * the code is easier to read and closer to the mathematical formulation of the problem.
+  * sparse matrix-vector products are available, which can be much faster than a dense one.
+  * the derivatives w.r.t (params_obj, params_eq, params_ineq) may be easier to compute
+    than materializing the full matrix.
+  * it is faster than the quadratic function API.
+
+This is the recommended API to use when the matrices are not block diagonal operators,
+especially when there are other sparsity patterns involved, or in conjunction with
+implicit differentiation::
+
+  # Objective:
+  #     min ||data @ x - targets||_2^2 + 2 * n * lam ||x||_1
+  #
+  # With BoxOSQP formulation:
+  #
+  #     min_{x, y, t} y^Ty + 2*n*lam 1^T t
+  #     under       targets = data @ x - y
+  #           0         <= x + t <= infinity
+  #           -infinity <= x - t <= 0
+  data, targets = datasets.make_regression(n_samples=10, n_features=3, random_state=0)
+  lam = 10.0
+
+  def matvec_Q(params_Q, xyt):
+    del params_Q  # unused
+    x, y, t = xyt
+    return jnp.zeros_like(x), 2 * y, jnp.zeros_like(t)
+
+  c = jnp.zeros(data.shape[1]), jnp.zeros(data.shape[0]), 2*n*lam * jnp.ones(data.shape[1])
+
+  def matvec_A(params_A, xyt):
+    x, y, t = xyt
+    residuals = params_A @ x - y
+    return residuals, x + t, x - t
+
+  l = targets, jnp.zeros_like(c[0]), jnp.full(data.shape[1], -jnp.inf)
+  u = targets, jnp.full(data.shape[1], jnp.inf), jnp.zeros_like(c[0])
+
+  hyper_params = dict(params_obj=(None, c), params_eq=data, params_ineq=(l, u))
+  osqp = BoxOSQP(matvec_Q=matvec_Q, matvec_A=matvec_A, tol=1e-2)
+  sol, state = osqp.run(None, **hyper_params)
+
+Quadratic function API
+----------------------
+
+Solvers :class:`EqualityConstrainedQP`, :class:`OSQP` and :class:`BoxOSQP` support the quadratic function API.
+It means that the whole objective function `x -> 1/2 x^T Q x + c^T x + K` can be provided as a function
+``fun`` that computes the quadratic function. The function must be differentiable w.r.t `x`.
+
+It offers several advantages:
+  * the code is easier to read and closer to the mathematical formulation of the problem.
+  * there is no need to provide the matrix `Q` and the vector `c` separately, nor to remove the constant term `K`.
+  * the derivatives w.r.t (params_obj, params_eq, params_ineq) may be even easier to compute
+    than materializing the full matrix.
+
+Take care that this API also have drawbacks:
+  * the function ``fun`` must be differentiable w.r.t `x` (with Jax's AD), even if you are not interested in the derivatives of your QP.
+  * to extract `x -> Qx` and `c` from the function, we need to compute the Hessian-vector product and the gradient of ``fun``, which may be expensive.
+  * for this API `init_params` must be provided to `run`, contrary to the other APIs.
+
+We illustrate this API with Non Negative Least Squares (NNLS)::
+
+  #  min_W \|Y-UW\|_F^2
+  #  s.t. W>=0
+  n, m, rank = 20, 10, 3
+  onp.random.seed(654)
+  U = jax.nn.relu(onp.random.randn(n, rank))
+  W_0 = jax.nn.relu(onp.random.randn(rank, m))
+  Y = U @ W_0
+
+  def fun(W, params_obj):
+    Y, U = params_obj
+    # Write the objective as an implicit quadratic polynomial
+    return jnp.sum(jnp.square(Y - U @ W))
+
+  def matvec_G(params_G, W):
+    del params_G  # unused
+    return -W
+
+  zeros = jnp.zeros_like(W_0)
+  hyper_params = dict(params_obj=(Y, U), params_eq=None, params_ineq=(None, zeros))
+
+  solver = OSQP(fun=fun, matvec_G=matvec_G)
+
+  init_W = jnp.zeros_like(W_0)  # mandatory with `fun` API.
+  init_params = solver.init_params(init_W, **hyper_params)
+  W_sol = solver.run(init_params=init_params, **hyper_params).params.primal
+
+This API is not recommended for large-scale problems or nested differentiations, use matvec API instead.
+
+Implicit differentiation pitfalls
+---------------------------------
+
+When using implicit differentiation, the parameters w.r.t which we differentiate
+must be passed to `params_obj`, `params_eq` or `params_ineq`. They should not be captured
+from the global scope by `fun` or `matvec`. We illustrate below this common mistake::
+
+  def wrong_solver(Q):  # don't do this!
+
+    def matvec_Q(params_Q, x):
+      del params_Q  # unused
+      # error! Q is captured from the global scope.
+      # it does not fail now, but it will fail later.
+      return jnp.dot(Q, x)
+    
+    c = jnp.zeros(Q.shape[0])
+
+    A = jnp.array([[1.0, 2.0]])
+    b = jnp.array([1.0])
+
+    eq_qp = EqualityConstrainedQP(matvec_Q=matvec_Q)
+    sol = eq_qp.run(None, params_obj=(None, c), params_eq=(A, b)).params
+    loss = jnp.sum(sol.primal)
+    return loss
+
+  Q = jnp.array([[1.0, 0.5], [0.5, 4.0]])
+  _ = wrong_solver(Q)  # no error... but it will fail later.
+  _ = jax.grad(wrong_solver)(Q)  # raise CustomVJPException
+
+Also, notice that since the problems are convex, the optimum is independent of the
+starting point `init_params`. Hence, derivatives w.r.t `init_params` are always
+zero (mathematically).
+
+The correct implementation is given below::
+
+  def correct_solver(Q):
+
+    def matvec_Q(params_Q, x):
+      return jnp.dot(params_Q, x)
+    
+    c = jnp.zeros(Q.shape[0])
+
+    A = jnp.array([[1.0, 2.0]])
+    b = jnp.array([1.0])
+
+    eq_qp = EqualityConstrainedQP(matvec_Q=matvec_Q)
+    # Q is passed as a parameter, not captured from the global scope.
+    sol = eq_qp.run(None, params_obj=(Q, c), params_eq=(A, b)).params
+    loss = jnp.sum(sol.primal)
+    return loss
+
+  Q = jnp.array([[1.0, 0.5], [0.5, 4.0]])
+  _ = correct_solver(Q)  # no error
+  _ = jax.grad(correct_solver)(Q)  # no error

--- a/jaxopt/_src/osqp.py
+++ b/jaxopt/_src/osqp.py
@@ -21,6 +21,7 @@ from typing import Callable
 from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 import jax
 import jax.nn as nn
@@ -47,23 +48,59 @@ def projection_box(x: Any, hyperparams: Tuple) -> Any:
   return tree_map(_clip_safe, x, lower, upper)
 
 
-def _make_osqp_optimality_fun(matvec_Q, matvec_A):
+def extract_Qc_from_obj(x: Any,
+                        params_obj: Union[Tuple[Any, Any], Any],
+                        fun: Optional[Callable]):
+  """Returns (params_Q, c) parameters from params_obj.
+
+  Args:
+    x: pytree with same shape and same type as the input of fun; leaves can have any value.
+    params_obj: parameters of objective function.
+      Either a pair (params_Q, c) or an arbitrary pytree if fun is not None.
+    fun: objective function.
+  
+  When `fun` is `None` it retrieves the relevant informations from the tuple `params_obj`,
+  whereas when `fun` is not `None` it extracts it using AutoDiff.
+  """
+  if fun is None:
+    params_Q, c = params_obj
+    return params_Q, c
+  zeros = tree_zeros_like(x)
+  # f(x) := 0.5 * x^T Q x + c^T x + cste
+  value_and_grad_fun = jax.value_and_grad(fun, argnums=0)
+  # nabla_x f(x) = Q x + c
+  # f(0)         = cste
+  # Q is never extracted explicitly, only its action on vectors is needed
+  cste, c = value_and_grad_fun(zeros, params_obj)
+  return (params_obj, c, cste), c
+
+
+def _make_osqp_optimality_fun(matvec_Q, matvec_A, fun):
   """Makes the optimality function for BoxOSQP.
+
+  Args:
+    matvec_Q: function that computes Qx.
+    matvec_A: function that computes Ax.
+    fun: function that computes the quadratic objective.
 
   Returns:
     optimality_fun(params, params_obj, params_eq, params_ineq) where
       params = (primal_var, eq_dual_var, ineq_dual_var)
-      params_obj = (P, c)
+      params_obj = (params_Q, c) or an arbitrary pytree if fun is not None
       params_eq = A
       params_ineq = (l, u)
   """
-  def obj_fun(primal_var, params_obj):
-    x, _ = primal_var
-    params_Q, c = params_obj
-    Q = matvec_Q(params_Q)
-    # minimize 0.5 x^T Q x + c^T x
-    qp_obj = tree_add_scalar_mul(tree_vdot(c, x), 0.5, tree_vdot(x, Q(x)))
-    return qp_obj
+
+  if fun is None:
+    def obj_fun(primal_var, params_obj):
+      x, _ = primal_var
+      params_Q, c = extract_Qc_from_obj(x, params_obj, fun)
+      Q = matvec_Q(params_Q)
+      # minimize 0.5 x^T Q x + c^T x
+      qp_obj = tree_add_scalar_mul(tree_vdot(c, x), 0.5, tree_vdot(x, Q(x)))
+      return qp_obj
+  else:
+    obj_fun = fun
 
   def eq_fun(primal_var, params_eq):
     # constraint Ax=z associated to y^T(Ax-z)=0
@@ -268,7 +305,10 @@ class BoxOSQP(base.IterativeSolver):
   """Operator Splitting Solver for Quadratic Programs.
 
   Jax implementation of the celebrated GPU-OSQP [1,3] based on ADMM.
-  Suppports jit, vmap, matvecs and pytrees.
+  Suppports jit, vmap, matvecs, pytrees and fun.
+
+  Refer to the doc of `init_state` method for the meaning of the parameters
+  in `run` and `update` methods.
 
   It solves convex problems of the form
 
@@ -306,6 +346,7 @@ class BoxOSQP(base.IterativeSolver):
   Attributes:
     matvec_Q: (optional) a Callable matvec_Q(params_Q, x).
       By default, matvec_Q(P, x) = tree_dot(P, x), where the pytree Q = params_Q matches x structure.
+      The shape of primal variables may be inferred from params_obj = (matvec_Q, c).
     matvec_A: (optional) a Callable matvec_A(params_A, x).
       By default, matvec_A(A, x) = tree_dot(A, x), where tree pytree A = params_A matches x structure.
     fun: (optional) a function with signature fun(params, params_obj) that is promised
@@ -315,6 +356,10 @@ class BoxOSQP(base.IterativeSolver):
       (Q, c) do not need to be explicited in params_obj by the user: c will be inferred by Jaxopt,
         and the operator x -> Qx will be computed upon request.
       ``fun`` incompatible with the specification of ``matvec_Q``.
+      Note that the shape of primal cannot be inferred from params_obj anymore,
+      so the user should provide it in init_params.
+      This API is provided for convenience, but note that since `fun` uses Jax's autodiff under the hood,
+      it can be slower than `matvec_Q`, especially when used in conjunction with implicit differentiation.
     check_primal_dual_infeasability: if True populates the ``status`` field of ``state``
       with one of ``BoxOSQP.PRIMAL_INFEASIBLE``, ``BoxOSQP.DUAL_INFEASIBLE``.
       If False it improves speed but does not check feasability.
@@ -392,10 +437,28 @@ class BoxOSQP(base.IterativeSolver):
   DUAL_INFEASIBLE   = 2  # infeasible dual (infeasible primal or unbounded primal).
   PRIMAL_INFEASIBLE = 3  # infeasible primal.
 
-  def init_state(self, init_params, params_obj, params_eq, params_ineq):
+  def init_state(self,
+                 init_params: base.KKTSolution,
+                 params_obj: Union[Tuple[Any, Any], Any],
+                 params_eq: Any,
+                 params_ineq: Tuple[Any, Any]):
+    """Initializes the solver state.
+
+    Args:
+      init_params: initial primal and dual variables (KKTSolution).
+      params_obj: parameters of the quadratic objective, can be:
+        a tuple (Q, c) with Q a pytree of matrices,
+        or a tuple (params_Q, c) if ``matvec_Q`` is provided,
+        or an arbitrary pytree if ``fun`` is provided.
+      params_eq: parameters of the equality constraints (see doc of run method).
+      params_ineq: parameters of the inequality constraints (see doc of run method).
+    
+    Returns:
+      A BoxOSQPState object.
+    """
     x, z = init_params.primal
     y    = init_params.dual_eq
-    Q_params, c = self._get_Q_c(x, params_obj)
+    Q_params, c = extract_Qc_from_obj(x, params_obj, self.fun)
     Q    = self.matvec_Q(Q_params)
     A    = self.matvec_A(params_eq)
 
@@ -411,9 +474,27 @@ class BoxOSQP(base.IterativeSolver):
                         rho_bar=self.rho_start,
                         solver_state=solver_state)
 
-  def init_params(self, init_x, params_obj, params_eq, params_ineq):
-    """Return default params for initialization."""
+  def init_params(self,
+                  init_x: Any,
+                  params_obj: Union[Tuple[Any, Any], Any],
+                  params_eq: Any,
+                  params_ineq: Tuple[Any, Any]):
+    """Return default KKTSolution for initialization of the solver state.
+    
+    Args:
+      init_x: initial primal variable.
+      params_obj: parameters of the objective function (see doc of init_state method).
+      params_eq: parameters of the equality constraints (see doc of init_state method).
+      params_ineq: parameters of the inequality constraints (see doc of init_state method).
+
+    Returns:
+      init_params: default parameters for initialization.
+    """
     if init_x is None:
+      # assume params_obj = (params_Q, c)
+      # generally incompatible with the use of ``fun``.
+      if self.fun is not None:
+        raise ValueError("init_x must be provided when fun is not None.")
       init_x = tree_zeros_like(params_obj[1])
     init_z = projection_box(self.matvec_A(params_eq)(init_x), params_ineq)
     init_y = tree_zeros_like(init_z)
@@ -583,7 +664,12 @@ class BoxOSQP(base.IterativeSolver):
 
     return (x_next, z_next), y_next, solver_state
 
-  def update(self, params, state, params_obj, params_eq, params_ineq):
+  def update(self,
+             params: base.KKTSolution,
+             state: BoxOSQPState,
+             params_obj: Union[Tuple[Any, Any], Any],
+             params_eq: Any,
+             params_ineq: Tuple[Any, Any]):
     """Perform BoxOSQP step."""
     # The original problem on variables (x,z) is split into TWO problems
     # with variables (x, z) and (x_bar, z_bar)
@@ -600,8 +686,8 @@ class BoxOSQP(base.IterativeSolver):
     # for equality constraint z = z_bar the associated dual variable is y
     jit, _ = self._get_loop_options()
 
-    Q_params, c = self._get_Q_c(params.primal[0], params_obj)
-    Q    = self.matvec_Q(Q_params)
+    params_Q, c = extract_Qc_from_obj(params.primal[0], params_obj, self.fun)
+    Q    = self.matvec_Q(params_Q)
     A    = self.matvec_A(params_eq)
     l, u = params_ineq
 
@@ -660,10 +746,16 @@ class BoxOSQP(base.IterativeSolver):
 
     Args:
       init_params: (optional) initial KKTSolution.
-      params_obj: pair (params_Q, c).
+        Must be provided if ``fun`` is not None.
+      params_obj: parameters of objective, can be:
+        a tuple (Q, c) with Q a pytree of matrices,
+        or a tuple (params_Q, c) if ``matvec_Q`` is provided,
+        or an arbitrary pytree if ``fun`` is provided.
       params_eq: (optional) params_A.
       params_ineq: pair (l, u).
     """
+    # Default to None for consistency of signatures
+    # Should be set by the user anyway.
     assert params_obj is not None
     assert params_ineq is not None
 
@@ -671,24 +763,6 @@ class BoxOSQP(base.IterativeSolver):
       init_params = self.init_params(None, params_obj, params_eq, params_ineq)
     
     return super().run(init_params, params_obj, params_eq, params_ineq)
-
-  def _get_Q_c(self, x, params_obj):
-    """Returns (Q, c) parameters from params_obj.
-
-    Args:
-      x: pytree with same shape and same type as the input of self.fun; leaves can have any value
-      params_obj: parameters of objective function
-    
-    When `fun` is `None` it retrieves the relevant informations from the tuple `params_obj`,
-    whereas when `fun` is not `None` it extracts it using AutoDiff.
-    """
-    if self.fun is None:
-      params_Q, c = params_obj
-      return params_Q, c
-    zeros = tree_zeros_like(x)
-    value_and_grad_fun = jax.value_and_grad(self.fun, argnums=0)
-    cste, c = value_and_grad_fun(zeros, params_obj)
-    return (params_obj, c, cste), c
 
   def l2_optimality_error(
       self,
@@ -707,6 +781,9 @@ class BoxOSQP(base.IterativeSolver):
     if self.fun is not None:
       def matvec_Q(params_obj, x):
         params_Q, c, _ = params_obj
+        # f(x) = 0.5 * x^T Q x + c^T x + cste
+        # nabla_x f(x) = Q x + c
+        # Qx = nabla_x f(x) - c
         def fun_minus_cx(xx):
           return self.fun(xx, params_Q) - jnp.sum(c*xx)
         Qx = jax.grad(fun_minus_cx)(x)
@@ -732,7 +809,7 @@ class BoxOSQP(base.IterativeSolver):
       jit, _ = self._get_loop_options()
       self.check_primal_dual_infeasability = not jit
 
-    self.optimality_fun = _make_osqp_optimality_fun(self.matvec_Q, self.matvec_A)
+    self.optimality_fun = _make_osqp_optimality_fun(self.matvec_Q, self.matvec_A, self.fun)
 
 
 class OSQP_to_BoxOSQP:
@@ -782,10 +859,9 @@ class OSQP_to_BoxOSQP:
     # when matvec_A is None and matvec_G is None we MUST concatenate rows of constraints to ensure
     # that pre-conditioning is still possible.
 
-    # TODO(lbethune): does it make sense to support QP without constraints ?
-    # should the user switch to another solver instead ? (e.g conjugate gradient... )
     if params_eq is None and params_ineq is None:
-      raise ValueError("At least one of params_eq or params_ineq must be not None.")
+      raise ValueError("At least one of params_eq or params_ineq must be not None." \
+                       "When there are no constraints we suggest direct solving of the QP with a conjugate gradient solver.")
 
     eq_size, ineq_neg_size = None, None
     A, G = None, None
@@ -863,6 +939,7 @@ class OSQP(base.Solver):
   """OSQP solver for general quadratic programming.
 
   Meant as drop-in replacement for CvxpyQP.
+  Depending on the format of your problem, BoxOSQP API may be more appropriate.
   Support for matvec and pytrees. Supports jit and vmap.
 
   CvxpyQP is more precise and should be preferred on CPU.
@@ -878,6 +955,8 @@ class OSQP(base.Solver):
   Attributes:
     matvec_Q: (optional) a Callable matvec_Q(params_Q, x).
       By default, matvec_Q(P, x) = tree_dot(P, x), where the pytree Q = params_Q matches x structure.
+      ``matvec_Q`` incompatible with the specification of ``fun``.
+      The shape of primal variables may be inferred from params_obj = (matvec_Q, c).
     matvec_A: (optional) a Callable matvec_A(params_A, x).
       By default, matvec_A(A, x) = tree_dot(A, x), where tree pytree A = params_A matches x structure.
     matvec_G: (optional) a Callable matvec_G(params_G, x).
@@ -889,6 +968,8 @@ class OSQP(base.Solver):
       (Q, c) do not need to be explicited in params_obj by the user: c will be inferred by Jaxopt,
         and the operator x -> Qx will be computed upon request.
       ``fun`` incompatible with the specification of ``matvec_Q``.
+      Note that the shape of primal cannot be inferred from params_obj anymore,
+      so the user should provide it in init_params.
     check_primal_dual_infeasability: if True populates the ``status`` field of ``state``
       with one of ``BoxOSQP.PRIMAL_INFEASIBLE``, ``BoxOSQP.DUAL_INFEASIBLE``. (default: True).
       If False it improves speed but does not check feasability.
@@ -931,13 +1012,25 @@ class OSQP(base.Solver):
     matvec_Q, matvec_A_box = OSQP_to_BoxOSQP.transform_matvec(matvec_Q, matvec_A, matvec_G)
     self.matvec_A_box = matvec_A_box
 
+    # meant as drop-in replacement for CvxpyQP for which no unrolling is available.
     self._box_osqp = BoxOSQP(matvec_Q=matvec_Q,
                              matvec_A=matvec_A_box,
                              fun=fun,
-                             implicit_diff=True, **kwargs)
+                             implicit_diff=True,
+                             **kwargs)
 
   def init_params(self, init_x, params_obj, params_eq, params_ineq):
-    """Return default params for initialization."""
+    """Return default params for initialization.
+    
+    Args:
+      init_x: initial primal solution. 
+      params_obj: see the doc of `run` method.
+      params_eq: see the doc of `run` method.
+      params_ineq: see the doc of `run` method.
+    
+    Returns:
+      init_params: a pytree KKTSolution of parameters for BoxOSQP.
+    """
     _, hyper_params, eq_ineq_size = OSQP_to_BoxOSQP.transform(self.matvec_A_box,
                                                               None, params_obj,
                                                               params_eq, params_ineq)
@@ -946,16 +1039,20 @@ class OSQP(base.Solver):
 
   def run(self,
           init_params: Any = None,
-          params_obj: Tuple[Optional[Any], Any] = None,
+          params_obj: Union[Tuple[Any, Any], Any] = None,
           params_eq: Optional[Tuple[Any,Any]] = None,
           params_ineq: Optional[Tuple[Any,Any]] = None) -> base.OptStep:
-    """Runs the quadratic programming solver in Cvxpy.
+    """Runs the quadratic programming solver in BoxOSQP.
 
     The returned params contains both the primal and dual solutions.
 
     Args:
-      init_params: (optional) init_params for warm_start.
-      params_obj: (Q, c).
+      init_params: init_params: (optional) initial KKTSolution for warm-start.
+        Must be provided if ``fun`` is not None.
+      params_obj: parameters of the quadratic objective, can be:
+        a tuple (Q, c) with Q a pytree of matrices,
+        or a tuple (params_Q, c) if ``matvec_Q`` is provided,
+        or an arbitrary pytree if ``fun`` is provided.
       params_eq: (A, b) or None if no equality constraints.
       params_ineq: (G, h) or None if no inequality constraints.
     Returns:
@@ -978,10 +1075,13 @@ class OSQP(base.Solver):
 
   def l2_optimality_error(self,
     params: jnp.array,
-    params_obj: base.ArrayPair,
+    params_obj: Union[base.ArrayPair, Any],
     params_eq: Optional[base.ArrayPair],
     params_ineq: Optional[base.ArrayPair]):
-    """Computes the L2 norm of the KKT residuals."""
+    """Computes the L2 norm of the KKT residuals.
+    
+    Note that this function is exposed for consistency of the API, but the differentiation is actually
+    performed in the BoxOSQP class."""
     params, hyper_params, _ = OSQP_to_BoxOSQP.transform(self.matvec_A_box,
                                                         params, params_obj,
                                                         params_eq, params_ineq)

--- a/tests/eq_qp_test.py
+++ b/tests/eq_qp_test.py
@@ -22,6 +22,7 @@ from jaxopt import projection
 from jaxopt.base import KKTSolution
 from jaxopt import EqualityConstrainedQP
 from jaxopt._src import test_util
+from jaxopt._src.tree_util import tree_negative
 
 import numpy as onp
 
@@ -109,8 +110,31 @@ class EqualityConstrainedQPTest(test_util.JaxoptTestCase):
     self.assertArraysAllClose(primal_sol, expected)
     self.assertAllClose(qp.l2_optimality_error(sol, **hyperparams), 0.0)
 
+  def test_pytree_api(self):
+    Q1 = jnp.array([[1.0, -0.5],
+                  [-0.5, 1.0]])
+    Q2 = jnp.array([[2.0]])
+    Q = {'problem1': Q1, 'problem2': Q2}
+
+    c1 = jnp.array([-0.4, 0.3])
+    c2 = jnp.array([0.1])
+    c = {'problem1': c1, 'problem2': c2}
+
+    a1 = jnp.array([[-0.5, 1.5]])
+    a2 = jnp.array([[10.0]])
+    A = {'problem1': a1, 'problem2': a2}
+
+    b1 = jnp.array([0.3])
+    b2 = jnp.array([5.0])
+    b = {'problem1': b1, 'problem2': b2}
+
+    qp = EqualityConstrainedQP(tol=1e-3)
+    hyperparams = dict(params_obj=(Q, c), params_eq=(A, b))
+    # Test that there is no error when running the solver.
+    sol = qp.run(**hyperparams).params
+
   @parameterized.product(refine_regularization=[0., 1e-6])
-  def test_eq_constrained_qp_with_pytrees(self, refine_regularization):
+  def test_matvec_api(self, refine_regularization):
     # refine_regularization != 0. triggers a non regression test for issue #311
     rng = onp.random.RandomState(0)
     Q = rng.randn(7, 7)
@@ -152,6 +176,87 @@ class EqualityConstrainedQPTest(test_util.JaxoptTestCase):
     # Check that the solutions match.
     self.assertArraysAllClose(jnp.concatenate(sol_pytree.primal), sol.primal, atol=1e-4)
     self.assertArraysAllClose(sol_pytree.dual_eq, sol.dual_eq, atol=1e-4)
+
+  def test_fun_api(self):
+    # mimic a function with pytree parameters.
+    x = {'complicated_pytree': jnp.array([1.0, 2.0])}
+    a = jnp.array([-0.5, 1.5])
+    b = jnp.array(0.3)
+
+    # convex quadratic and pytree parameters.
+    def euclidean_quadratic_cost(y, params_obj):
+      x = params_obj['complicated_pytree']
+      return jnp.sum((x - y)*(x - y))
+    
+    def matvec_A(params_A, u):
+      return jnp.dot(params_A, u).reshape(1)
+    
+    qp = EqualityConstrainedQP(fun=euclidean_quadratic_cost,
+                               matvec_A=matvec_A)    
+
+    try:
+      # attempt to run without providing init_params, despite fun != None.
+      hyperparams = dict(params_obj=x, params_eq=(a, b))
+      sol = qp.run(**hyperparams).params
+    except ValueError as e:
+      pass  # here, a failure is the expected behavior.
+    else:
+      self.fail("Expected ValueError when init_params is not provided (`fun` API).")
+
+    def scalar_solve_qp(hyperparams, init_params):
+      params = qp.run(init_params, **hyperparams).params
+      # arbitrary scalar function to ensure that the gradient is defined.
+      return jnp.sum(params.primal)  
+
+    hyperparams = dict(params_obj=x, params_eq=(a, jnp.array([b])))
+    init_params = KKTSolution(jnp.array([1.0, 1.0]), jnp.array([1.0]))
+
+    solve_value_grad = jax.value_and_grad(scalar_solve_qp)
+    # we only need to test if the gradient is well defined in reverse mode AD:
+    sol, unused_grad = solve_value_grad(hyperparams, init_params)
+
+  def test_example_from_doc(self):
+    """Test the example exposed in quadratic_problems.rst"""
+    Q = jnp.array([[1.0, 0.5], [0.5, 4.0]])
+    c = jnp.zeros(Q.shape[0])
+    A = jnp.array([[1.0, 2.0]])
+    b = jnp.array([1.0])
+
+    def wrong_solver(Q):  # don't do this!
+
+      def matvec_Q(params_Q, x):
+        del params_Q  # unused
+        # error! Q is captured from the global scope.
+        # it does not fail now, but it will later.
+        return jnp.dot(Q, x)
+      
+      eq_qp = EqualityConstrainedQP(matvec_Q=matvec_Q)
+      # Warning: Q does not appear in the call to run()
+      sol = eq_qp.run(None, params_obj=(None, c), params_eq=(A, b)).params
+      loss = jnp.sum(sol.primal)
+      return loss
+
+    _ = wrong_solver(Q)  # no error... but it will fail later.
+    try:
+      _ = jax.grad(wrong_solver)(Q)  # error!
+    except jax._src.interpreters.ad.CustomVJPException as e:
+      pass  # here, a failure is the expected behavior.
+    else:
+      self.fail("Expected CustomVJPException when matvec_Q captures Q.")
+
+    def correct_solver(Q):
+
+      def matvec_Q(params_Q, x):
+        return jnp.dot(params_Q, x)
+
+      eq_qp = EqualityConstrainedQP(matvec_Q=matvec_Q)
+      # Q is passed as a parameter, not captured from the global scope.
+      sol = eq_qp.run(None, params_obj=(Q, c), params_eq=(A, b)).params
+      loss = jnp.sum(sol.primal)
+      return loss
+
+    _ = correct_solver(Q)  # no error
+    _ = jax.grad(correct_solver)(Q)  # no error
 
   def test_challenging_problem(self):
     size_prob = 100


### PR DESCRIPTION
New convenience API `fun` for EqualityConstrainedQP.

I also improved the documentation of Quadratic Programming in general, since several features were not properly documented. In particular we have four majors API for quadratic programming:

* dense matrices
* pytree of dense matrices (separable problems)
* matvecs
* quadratic fun

I documented those API with examples, and I added some unit-tests corresponding to the code given in documentation. I also added an "Implicit Differentiation pitfalls" section in quadratic programming, to illustrate a frequent mistake of users trying to differentiate their QP. This may be used in the future to answer questions or issues.

This should close issue #207