### PR TITLE
Support for complex parameter optimization

### DIFF
--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -26,13 +26,15 @@ from jaxopt._src import base
 from jaxopt._src.linesearch_util import _init_stepsize
 from jaxopt._src.linesearch_util import _setup_linesearch
 from jaxopt._src.tree_util import tree_single_dtype
+from jaxopt._src.tree_util import get_real_dtype
 from jaxopt.tree_util import tree_add_scalar_mul
+from jaxopt.tree_util import tree_conj
 from jaxopt.tree_util import tree_l2_norm
 from jaxopt.tree_util import tree_map
 from jaxopt.tree_util import tree_scalar_mul
 from jaxopt.tree_util import tree_sub
 from jaxopt.tree_util import tree_sum
-from jaxopt.tree_util import tree_vdot
+from jaxopt.tree_util import tree_vdot_real
 
 
 def select_ith_tree(tree_history, i):
@@ -47,7 +49,7 @@ def inv_hessian_product(pytree: Any,
                         start: int = 0):
   """Product between an approximate Hessian inverse and a pytree.
 
-  Histories are pytrees of the same structure as `pytree` except 
+  Histories are pytrees of the same structure as `pytree` except
   that the leaves are arrays of shape `(history_size, ...)`, where
   `...` means the same shape as `pytree`'s leaves.
 
@@ -79,7 +81,7 @@ def inv_hessian_product(pytree: Any,
 
   def body_right(r, i):
     si, yi = select_ith_tree(s_history, i), select_ith_tree(y_history, i)
-    alpha = rho_history[i] * tree_vdot(si, r)
+    alpha = rho_history[i] * tree_vdot_real(si, r)
     r = tree_add_scalar_mul(r, -alpha, yi)
     return r, alpha
   r, alpha = jax.lax.scan(body_right, pytree, indices, reverse=True)
@@ -89,7 +91,7 @@ def inv_hessian_product(pytree: Any,
   def body_left(r, args):
     i, alpha = args
     si, yi = select_ith_tree(s_history, i), select_ith_tree(y_history, i)
-    beta = rho_history[i] * tree_vdot(yi, r)
+    beta = rho_history[i] * tree_vdot_real(yi, r)
     r = tree_add_scalar_mul(r, alpha - beta, si)
     return r, beta
   r, _ = jax.lax.scan(body_left, r, (indices, alpha))
@@ -104,10 +106,10 @@ def compute_gamma(s_history: Any, y_history: Any, last: int):
   # See Numerical Optimization, second edition, equation (7.20).
   # Note that unlike BFGS, the initialization can change on every iteration.
 
-  fun = lambda s_history, y_history: tree_vdot(y_history[last], s_history[last])
+  fun = lambda s_history, y_history: tree_vdot_real(y_history[last], s_history[last])
   num = tree_sum(tree_map(fun, s_history, y_history))
 
-  fun = lambda y_history: tree_vdot(y_history[last], y_history[last])
+  fun = lambda y_history: tree_vdot_real(y_history[last], y_history[last])
   denom = tree_sum(tree_map(fun, y_history))
 
   return jnp.where(denom > 0, num / denom, 1.0)
@@ -144,6 +146,8 @@ class LbfgsState(NamedTuple):
 @dataclass(eq=False)
 class LBFGS(base.IterativeSolver):
   """LBFGS solver.
+
+  Supports complex variables, see second reference.
 
   Attributes:
     fun: a smooth function of the form ``fun(x, *args, **kwargs)``.
@@ -194,10 +198,14 @@ class LBFGS(base.IterativeSolver):
     verbose: whether to print error on every iteration or not.
       Warning: verbose=True will automatically disable jit.
 
-  Reference:
+  References:
     Jorge Nocedal and Stephen Wright.
     Numerical Optimization, second edition.
     Algorithm 7.5 (page 179).
+
+    Laurent Sorber, Marc van Barel, and Lieven de Lathauwer.
+    Unconstrained Optimization of Real Functions in Complex Variables.
+    SIAM J. Optim., Vol. 22, No. 3, pp. 879-898
   """
 
   fun: Callable
@@ -263,21 +271,21 @@ class LBFGS(base.IterativeSolver):
         stepsize=init_params.state.stepsize,
       )
       init_params = init_params.params
-      dtype = tree_single_dtype(init_params)
+      realdtype = get_real_dtype(tree_single_dtype(init_params))
     else:
-      dtype = tree_single_dtype(init_params)
+      realdtype = get_real_dtype(tree_single_dtype(init_params))
       state_kwargs = dict(
           s_history=init_history(init_params, self.history_size),
           y_history=init_history(init_params, self.history_size),
-          rho_history=jnp.zeros(self.history_size, dtype=dtype),
-          gamma=jnp.asarray(1.0, dtype=dtype),
+          rho_history=jnp.zeros(self.history_size, dtype=realdtype),
+          gamma=jnp.asarray(1.0, dtype=realdtype),
           iter_num=jnp.asarray(0),
-          stepsize=jnp.asarray(self.max_stepsize, dtype=dtype),
+          stepsize=jnp.asarray(self.max_stepsize, dtype=realdtype),
       )
     (value, aux), grad = self._value_and_grad_with_aux(init_params, *args, **kwargs)
     return LbfgsState(value=value,
                       grad=grad,
-                      error=jnp.asarray(jnp.inf, dtype=dtype),
+                      error=jnp.asarray(jnp.inf, dtype=realdtype),
                       **state_kwargs,
                       aux=aux,
                       failed_linesearch=jnp.asarray(False),
@@ -304,9 +312,11 @@ class LBFGS(base.IterativeSolver):
     if isinstance(params, base.OptStep):
       params = params.params
 
+    realdtype = state.rho_history.dtype  # avoid recomputation, take realdtype from initialized state
+
     start = state.iter_num % self.history_size
     value, grad = (state.value, state.grad)
-    descent_direction = tree_scalar_mul(-1.0, grad)
+    descent_direction = tree_scalar_mul(-1.0, tree_conj(grad))
     s_history = state.s_history
     y_history = state.y_history
     rho_history = state.rho_history
@@ -364,8 +374,8 @@ class LBFGS(base.IterativeSolver):
       new_num_linesearch_iter = state.num_linesearch_iter
       failed_linesearch = jnp.asarray(False)
     s = tree_sub(new_params, params)
-    y = tree_sub(new_grad, grad)
-    vdot_sy = tree_vdot(s, y)
+    y = tree_conj(tree_sub(new_grad, grad))
+    vdot_sy = tree_vdot_real(s, y)
     rho = jnp.where(vdot_sy == 0, 0, 1. / vdot_sy)
 
     if self.history_size:
@@ -376,15 +386,14 @@ class LBFGS(base.IterativeSolver):
     if self.history_size and self.use_gamma:
       gamma = compute_gamma(s_history, y_history, start)
     else:
-      gamma = jnp.array(1.0)
+      gamma = jnp.array(1.0, dtype=realdtype)
 
-    dtype = tree_single_dtype(params)
     error = tree_l2_norm(new_grad)
     new_state = LbfgsState(iter_num=state.iter_num + 1,
                            value=new_value,
                            grad=new_grad,
-                           stepsize=jnp.asarray(new_stepsize),
-                           error=jnp.asarray(error, dtype=dtype),
+                           stepsize=jnp.asarray(new_stepsize, dtype=realdtype),
+                           error=jnp.asarray(error, dtype=realdtype),
                            s_history=s_history,
                            y_history=y_history,
                            rho_history=rho_history,

--- a/jaxopt/tree_util.py
+++ b/jaxopt/tree_util.py
@@ -22,6 +22,7 @@ from jaxopt._src.tree_util import tree_scalar_mul
 from jaxopt._src.tree_util import tree_add_scalar_mul
 from jaxopt._src.tree_util import tree_dot
 from jaxopt._src.tree_util import tree_vdot
+from jaxopt._src.tree_util import tree_vdot_real
 from jaxopt._src.tree_util import tree_div
 from jaxopt._src.tree_util import tree_sum
 from jaxopt._src.tree_util import tree_l2_norm
@@ -30,3 +31,6 @@ from jaxopt._src.tree_util import tree_zeros_like
 from jaxopt._src.tree_util import tree_ones_like
 from jaxopt._src.tree_util import tree_negative
 from jaxopt._src.tree_util import tree_inf_norm
+from jaxopt._src.tree_util import tree_conj
+from jaxopt._src.tree_util import tree_real
+from jaxopt._src.tree_util import tree_imag

--- a/tests/linesearch_common_test.py
+++ b/tests/linesearch_common_test.py
@@ -1,0 +1,85 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+from jaxopt._src import test_util
+from jaxopt._src.linesearch_util import _init_stepsize
+from jaxopt._src.linesearch_util import _setup_linesearch
+
+
+class LinesearchTest(test_util.JaxoptTestCase):
+  @parameterized.product(linesearch=['zoom', 'backtracking', 'hager-zhang'], use_gradient=[False, True])
+  def test_linesearch_complex_variables(self, linesearch, use_gradient):
+    """test that optimization over complex variable z = x + jy matches equivalent real case"""
+
+    W = jnp.array(
+        [[1, - 2],
+          [3, 4],
+          [-4 + 2j, 5 - 3j],
+          [-2 - 2j, 6]]
+    )
+
+    def C2R(z):
+      return jnp.stack((z.real, z.imag)) if z is not None else None
+
+    def R2C(x):
+      return x[..., 0, :] + 1j * x[..., 1, :]  # if len(x)>0 else jnp.zeros_like(x)
+
+    def f(z):
+      return W @ z
+
+    def loss_complex(z):
+      return jnp.sum(jnp.abs(f(z)) ** 1.5)
+
+    def loss_real(zR):
+      return loss_complex(R2C(zR))
+
+    z0 = jnp.array([1 - 1j, 0 + 1j])
+
+    common_args = dict(value_and_grad=False, has_aux=False, maxlsiter=3, max_stepsize=1, jit=True, unroll=False, verbose=False)
+
+    ls_R = _setup_linesearch(
+        linesearch=linesearch,
+        fun=loss_real,
+        **common_args,
+    )
+
+    ls_C = _setup_linesearch(
+        linesearch=linesearch,
+        fun=loss_complex,
+        **common_args,
+    )
+
+    ls_state = _init_stepsize(
+        strategy='increase',
+        max_stepsize=1e-1,
+        min_stepsize=1e-3,
+        increase_factor=2.,
+        stepsize=1e-2,
+    )
+
+    descent_direction = -jnp.conj(jax.grad(loss_complex)(z0)) if use_gradient else None
+
+
+    stepsize_R, _ = ls_R.run(ls_state, params=C2R(z0), descent_direction = C2R(descent_direction))
+    stepsize_C, _ = ls_C.run(ls_state, params=z0, descent_direction = descent_direction)
+
+    self.assertArraysAllClose(stepsize_R, stepsize_C)
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
I started adding support for complex parameters, beginning with l-BFGS with zoom linesearch, see also issue #445.

The changes are rather straightforward and based on Sorber L, van Barel M, de Lathauwer L, Unconstrained Optimization of real functions in complex variables, SIAM J. Optim, Vol. 22, No. 3, pp. 879-898

* for some data, e.g., stepsize, change dtype to corresponding real dtype
* use complex conjugate of gradient for initial descent direction
* for dot products by vdot(x,y).real
* additionally, for testing, I made changes such that l-BFGS with zero history size falls back to gradient descent with linesearch

For real parameters these changes are removed when jitted, but could introduce some overhead without jitting. 

I plan to add support for more of the unbound optimizers and linesearch methods.
