### PR TITLE
Fixed bug 409 due to bad handling of NaN values in zoom linesearch

### DIFF
--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -273,7 +273,7 @@ class IterativeSolver(Solver):
   def _cond_fun(self, inputs):
     _, state = inputs[0]
     if self.verbose:
-      print("error:", state.error)
+      print(self.__class__.__name__ + " error:", state.error)
     return state.error > self.tol
 
   def _body_fun(self, inputs):

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -240,7 +240,7 @@ class LBFGS(base.IterativeSolver):
   def _cond_fun(self, inputs):
     _, state = inputs[0]
     if self.verbose:
-      print("error:", state.error)
+      print(self.__class__.__name__ + " error:", state.error)
     # We continue the optimization loop while the error tolerance is not met and,
     # either failed linesearch is disallowed or linesearch hasn't failed.
     return (state.error > self.tol) & jnp.logical_or(not self.stop_if_linesearch_fails, ~state.failed_linesearch)

--- a/jaxopt/_src/lbfgsb.py
+++ b/jaxopt/_src/lbfgsb.py
@@ -306,7 +306,7 @@ class LBFGSB(base.IterativeSolver):
   def _cond_fun(self, inputs):
     _, state = inputs[0]
     if self.verbose:
-      print("error:", state.error)
+      print(self.__class__.__name__ + " error:", state.error)
     # We continue the optimization loop while the error tolerance is not met
     # and either failed linesearch is disallowed or linesearch hasn't failed.
     return (state.error > self.tol) & jnp.logical_or(


### PR DESCRIPTION
Fixed bug [409](https://github.com/google/jaxopt/issues/409), added corresponding test, enhanced debugging messages (for linesearch and solvers).