### PR TITLE
Adding tests in python 3.11, fixing typing extension issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
             python-version: "${{ matrix.python-version }}"
       - name: Install dependencies

--- a/jaxopt/_src/levenberg_marquardt.py
+++ b/jaxopt/_src/levenberg_marquardt.py
@@ -15,13 +15,13 @@
 
 from typing import Any
 from typing import Callable
+from typing import Literal
 from typing import NamedTuple
 from typing import Optional
 from typing import Union
 
 from dataclasses import dataclass
 
-from typing_extensions import Literal
 import jax
 import jax.numpy as jnp
 


### PR DESCRIPTION
Current workflow is not tested on python 3.11, which generated issues, see #476. This PR attempts to fix the typing issue and add tests on python 3.11. 