### PR TITLE
Better layout for notebook gallery

### DIFF
--- a/docs/notebooks/index.rst
+++ b/docs/notebooks/index.rst
@@ -11,6 +11,8 @@ Deep learning
 
 .. raw:: html
 
+    <div class="sphx-glr-thumbnails">
+    
     <div class="sphx-glr-thumbcontainer" tooltip="Resnet example with Flax and JAXopt.">
 
 .. only:: html
@@ -41,16 +43,18 @@ Deep learning
 
     </div>
 
+    </div><!-- end sphx-glr-thumbnails -->
 
-.. raw:: html
 
-    <div class="sphx-glr-clear"></div>
+
 
 Implicit Differentiation
 ------------------------
 
 
 .. raw:: html
+
+    <div class="sphx-glr-thumbnails">
 
     <div class="sphx-glr-thumbcontainer" tooltip="Bi-level dataset distillation with JAXopt.">
 
@@ -64,7 +68,6 @@ Implicit Differentiation
 .. raw:: html
 
     </div>
-
 
 
 .. raw:: html
@@ -82,6 +85,8 @@ Implicit Differentiation
 
     </div>
 
+    </div><!-- end sphx-glr-thumbnails -->
+
 
 
 Distributed Optimization
@@ -89,6 +94,8 @@ Distributed Optimization
 
 
 .. raw:: html
+
+    <div class="sphx-glr-thumbnails">
 
     <div class="sphx-glr-thumbcontainer" tooltip="Distributed Optimization with JAXopt.">
 
@@ -102,7 +109,6 @@ Distributed Optimization
 .. raw:: html
 
     </div>
-
 
 
 .. raw:: html
@@ -121,12 +127,16 @@ Distributed Optimization
 
     </div>
 
+    </div><!-- end sphx-glr-thumbnails -->
+
 
 Perturbed optimizers
 --------------------
 
 
 .. raw:: html
+
+    <div class="sphx-glr-thumbnails">
 
     <div class="sphx-glr-thumbcontainer" tooltip="Perturbed optimizers with JAXopt.">
 
@@ -140,3 +150,6 @@ Perturbed optimizers
 .. raw:: html
 
     </div>
+
+    </div><!-- end sphx-glr-thumbnails -->
+


### PR DESCRIPTION
Something must have changed in sphinx-gallery, because the the layout of this page had very ugly margins. This commit fixes that.

Before: 
<img width="759" alt="image" src="https://github.com/google/jaxopt/assets/277639/f2b37055-703f-4201-b0cb-a3e9279d6d6d">

Now: 
<img width="782" alt="image" src="https://github.com/google/jaxopt/assets/277639/095149ae-c85e-47fc-a064-03e1c8b7e5b0">
