### PR TITLE
fix_optax_wrapper

### DIFF
--- a/jaxopt/_src/armijo_sgd.py
+++ b/jaxopt/_src/armijo_sgd.py
@@ -248,11 +248,7 @@ class ArmijoSGD(base.StochasticSolver):
     else:
       velocity = tree_zeros_like(init_params)
 
-    if self.has_aux:
-      value, aux = self.fun(init_params, *args, **kwargs)
-    else:
-      value = self.fun(init_params, *args, **kwargs)
-      aux = None
+    value, aux = self._fun_with_aux(init_params, *args, **kwargs)
 
     params_dtype = tree_single_dtype(init_params)
 
@@ -342,7 +338,7 @@ class ArmijoSGD(base.StochasticSolver):
 
     self._coef = 1 - self.aggressiveness
 
-    fun_with_aux, _, self._value_and_grad_with_aux = \
+    self._fun_with_aux, _, self._value_and_grad_with_aux = \
       base._make_funs_with_aux(fun=self.fun,
                                value_and_grad=self.value_and_grad,
                                has_aux=self.has_aux)
@@ -351,7 +347,7 @@ class ArmijoSGD(base.StochasticSolver):
 
     jit, unroll = self._get_loop_options()
 
-    armijo_with_fun = partial(armijo_line_search, fun_with_aux, unroll, jit)
+    armijo_with_fun = partial(armijo_line_search, self._fun_with_aux, unroll, jit)
     if jit:
       jitted_armijo = jax.jit(armijo_with_fun, static_argnums=(0,1))
       self._armijo_line_search = jitted_armijo

--- a/jaxopt/_src/optax_wrapper.py
+++ b/jaxopt/_src/optax_wrapper.py
@@ -105,11 +105,7 @@ class OptaxSolver(base.StochasticSolver):
     """
     opt_state = self.opt.init(init_params)
 
-    if self.has_aux:
-      value, aux = self.fun(init_params, *args, **kwargs)
-    else:
-      value = self.fun(init_params, *args, **kwargs)
-      aux = None
+    value, aux = self._fun(init_params, *args, **kwargs)
 
     params_dtype = tree_util.tree_single_dtype(init_params)
 
@@ -161,7 +157,7 @@ class OptaxSolver(base.StochasticSolver):
     return self._grad_fun(params, *args, **kwargs)[0]
 
   def __post_init__(self):
-    _, self._grad_fun, self._value_and_grad_fun = \
+    self._fun, self._grad_fun, self._value_and_grad_fun = \
       base._make_funs_with_aux(fun=self.fun,
                                value_and_grad=self.value_and_grad,
                                has_aux=self.has_aux)

--- a/jaxopt/_src/polyak_sgd.py
+++ b/jaxopt/_src/polyak_sgd.py
@@ -142,11 +142,7 @@ class PolyakSGD(base.StochasticSolver):
     Returns:
       state
     """
-    if self.has_aux:
-      value, aux = self.fun(init_params, *args, **kwargs)
-    else:
-      value = self.fun(init_params, *args, **kwargs)
-      aux = None
+    value, aux = self._fun(init_params, *args, **kwargs)
 
     if self.momentum == 0:
       velocity = None
@@ -221,7 +217,7 @@ class PolyakSGD(base.StochasticSolver):
     return hash(self.attribute_values())
 
   def __post_init__(self):
-    _, self._grad_fun, self._value_and_grad_fun = \
+    self._fun, self._grad_fun, self._value_and_grad_fun = \
       base._make_funs_with_aux(fun=self.fun,
                                value_and_grad=self.value_and_grad,
                                has_aux=self.has_aux)


### PR DESCRIPTION
The optax wrapper was not handling value_and_grad properly anymore due to the check of dtype in value (precisely at `value=jnp.asarray(jnp.inf, value.dtype)` where value was a tuple when `value_and_grad=True`) .
Here is a MWE. The fix is simple, I can add a test and review all similar calls of dtype of value if you want. (I needed this fix for a personal project but I can workaround).
```
import jax
from jax import numpy as jnp
from jaxopt import OptaxSolver
import optax

def fun(x): 
  return 0.5*x**2
val_and_grad_fun = jax.value_and_grad(fun)
solver = OptaxSolver(val_and_grad_fun, opt=optax.sgd(learning_rate=0.1), value_and_grad=True)
solver.run(jnp.asarray(1.))
# AttributeError: 'tuple' object has no attribute 'dtype'
```