### PR TITLE
support scalar output in lm

### DIFF
--- a/jaxopt/_src/levenberg_marquardt.py
+++ b/jaxopt/_src/levenberg_marquardt.py
@@ -43,7 +43,7 @@ class LevenbergMarquardtState(NamedTuple):
   damping_factor: float
   increase_factor: float
   residual: Any
-  loss: Any
+  value: Any
   delta: Any
   error: float
   gradient: Any
@@ -223,7 +223,7 @@ class LevenbergMarquardt(base.IterativeSolver):
         increase_factor=2,
         error=tree_l2_norm(gradient),
         residual=residual,
-        loss=0.5 * jnp.sum(jnp.square(residual)),
+        value=0.5 * jnp.sum(jnp.square(residual)),
         delta=delta_params,
         gradient=gradient,
         jac=jac,
@@ -360,7 +360,7 @@ class LevenbergMarquardt(base.IterativeSolver):
     """
 
     # Current value of the loss function F=0.5*||f||^2.
-    loss_curr = state.loss
+    loss_curr = state.value
 
     # TODO: clean up the linear_solver to take matrix directly and then clean up
     # linear equation solves below for materialize_jac=True to call them.
@@ -438,7 +438,7 @@ class LevenbergMarquardt(base.IterativeSolver):
         increase_factor=increase_factor,
         error=tree_l2_norm(gradient),
         residual=residual,
-        loss=0.5 * jnp.sum(jnp.square(residual)),
+        value=0.5 * jnp.sum(jnp.square(residual)),
         delta=delta_params,
         gradient=gradient,
         jac=jac,
@@ -548,4 +548,4 @@ class LevenbergMarquardt(base.IterativeSolver):
 
 def print_iteration(state: LevenbergMarquardtState):
   jax.debug.print("Iteration: {iter}, Cost: {cost}, ||Gradient||: {error}, Damping Factor: {damp}", 
-                iter=state.iter_num, cost=state.loss, error=state.error, damp=state.damping_factor)
+                iter=state.iter_num, cost=state.value, error=state.error, damp=state.damping_factor)

--- a/tests/levenberg_marquardt_test.py
+++ b/tests/levenberg_marquardt_test.py
@@ -78,7 +78,6 @@ class LevenbergMarquardtTest(test_util.JaxoptTestCase):
 
   def setUp(self):
     super().setUp()
-    self.test_in_x_64 = True
 
     self.substrate_conc = onp.array(
         [0.038, 0.194, .425, .626, 1.253, 2.500, 3.740])
@@ -316,6 +315,14 @@ class LevenbergMarquardtTest(test_util.JaxoptTestCase):
     self.assertAllClose(x_opt, x_gt, atol=1e-6)
     self.assertAllClose(state.aux, x_gt**2, atol=1e-6)
 
+  def test_scalar_output_fun(self):
+    lm = LevenbergMarquardt(
+        residual_fun=lambda x: x @ x,
+        tol=1e-1,)
+    x_init = jnp.ones((2,))
+    x_opt, _ = lm.run(x_init)
+
+    self.assertAllClose(x_opt, jnp.zeros((2,)), atol=1e0)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
this is just a simple update to the code to ensure that scalar function output are supported. Although less of interest, might be considered an edge case.