### PR TITLE
Reducing compilation times

### DIFF
--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -583,11 +583,6 @@ class CommonTest(test_util.JaxoptTestCase):
     init_params = 16*jnp.ones((dim,))
 
     for solver in solvers:
-      solver_name = f"{solver.__class__.__name__}"
-      if hasattr(solver, 'linesearch'):
-        solver_name += f" with {solver.linesearch} linesearch"
-      print(solver_name)
-
       stdout = io.StringIO()
       with redirect_stdout(stdout):
         solver_kwargs = {}
@@ -609,8 +604,11 @@ class CommonTest(test_util.JaxoptTestCase):
 
       num_compilations = stdout.getvalue().count("Compiled")
       # Goal would be self.assertTrue(num_compilations==1)
-      # For now, we simply print
-      print(f"Function compiled {num_compilations} times")
+      # For now, we simply print the number of times the function is compiled
+      solver_name = f"{solver.__class__.__name__}"
+      if hasattr(solver, 'linesearch'):
+        solver_name += f" with {solver.linesearch} linesearch"
+      print(f"{solver_name:<38}: objective compiled {num_compilations} times")
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
The plan of this PR is to reduce the number of times the objective function is compiled. 
I started by adding a test in common_tests to see how many times a function is compiled for each solver, see below for the results.
I will focus first on a simple solver like gradient descent to see if we can reduce the number of compilations.
Then I'll extend to each solver until the aforementioned test can be run to satisfy a single compilation of the objective.

```
AndersonWrapper                       : objective compiled 3 times
BFGS with zoom linesearch             : objective compiled 8 times
ArmijoSGD                             : objective compiled 5 times
GaussNewton                           : objective compiled 26 times
GradientDescent                       : objective compiled 3 times
LBFGS with zoom linesearch            : objective compiled 8 times
LBFGS with hager-zhang linesearch     : objective compiled 75 times
LBFGS with backtracking linesearch    : objective compiled 5 times
LevenbergMarquardt                    : objective compiled 30 times
NonlinearCG with zoom linesearch      : objective compiled 8 times
PolyakSGD                             : objective compiled 3 times
OptaxSolver                           : objective compiled 3 times
AndersonAcceleration                  : objective compiled 3 times
Broyden with backtracking linesearch  : objective compiled 11 times
Bisection                             : objective compiled 4 times
BlockCoordinateDescent                : objective compiled 5 times
LBFGSB with zoom linesearch           : objective compiled 8 times
ProjectedGradient                     : objective compiled 3 times
ProximalGradient                      : objective compiled 3 times
MirrorDescent                         : objective compiled 2 times
BacktrackingLineSearch                : objective compiled 5 times
HagerZhangLineSearch                  : objective compiled 40 times
ZoomLineSearch                        : objective compiled 6 times
```