### PR TITLE
FIX: TPU activation error

### DIFF
--- a/docs/notebooks/deep_learning/adversarial_training.ipynb
+++ b/docs/notebooks/deep_learning/adversarial_training.ipynb
@@ -71,7 +71,7 @@
     "try:\n",
     "    import jax.tools.colab_tpu\n",
     "    jax.tools.colab_tpu.setup_tpu()\n",
-    "except KeyError:\n",
+    "except (KeyError, RuntimeError):\n",
     "    print(\"TPU not found, continuing without it.\")\n",
     "from flax import linen as nn\n",
     "import jax\n",
@@ -571,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1 (main, Dec 23 2022, 09:28:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/notebooks/deep_learning/adversarial_training.md
+++ b/docs/notebooks/deep_learning/adversarial_training.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.15.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -65,7 +65,7 @@ import collections
 try:
     import jax.tools.colab_tpu
     jax.tools.colab_tpu.setup_tpu()
-except KeyError:
+except (KeyError, RuntimeError):
     print("TPU not found, continuing without it.")
 from flax import linen as nn
 import jax

--- a/docs/notebooks/distributed/custom_loop_pjit_example.ipynb
+++ b/docs/notebooks/distributed/custom_loop_pjit_example.ipynb
@@ -138,7 +138,7 @@
     "try:\n",
     "    import jax.tools.colab_tpu\n",
     "    jax.tools.colab_tpu.setup_tpu()\n",
-    "except KeyError:\n",
+    "except (KeyError, RuntimeError):\n",
     "    print(\"TPU not found, continuing without it.\")\n",
     "\n",
     "import jax\n",
@@ -558,7 +558,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.11.1 (main, Dec 23 2022, 09:28:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/notebooks/implicit_diff/dataset_distillation.ipynb
+++ b/docs/notebooks/implicit_diff/dataset_distillation.ipynb
@@ -88,7 +88,7 @@
     "try:\n",
     "    import jax.tools.colab_tpu\n",
     "    jax.tools.colab_tpu.setup_tpu()\n",
-    "except KeyError:\n",
+    "except (KeyError, RuntimeError):\n",
     "    print(\"TPU not found, continuing without it.\")\n",
     "\n",
     "import jax\n",
@@ -311,7 +311,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.11.1 (main, Dec 23 2022, 09:28:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/notebooks/implicit_diff/dataset_distillation.md
+++ b/docs/notebooks/implicit_diff/dataset_distillation.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.15.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -75,7 +75,7 @@ from matplotlib import pyplot as plt
 try:
     import jax.tools.colab_tpu
     jax.tools.colab_tpu.setup_tpu()
-except KeyError:
+except (KeyError, RuntimeError):
     print("TPU not found, continuing without it.")
 
 import jax

--- a/docs/notebooks/implicit_diff/maml.md
+++ b/docs/notebooks/implicit_diff/maml.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.15.1
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/perturbed_optimizers/perturbed_optimizers.ipynb
+++ b/docs/notebooks/perturbed_optimizers/perturbed_optimizers.ipynb
@@ -68,7 +68,7 @@
     "try:\n",
     "    import jax.tools.colab_tpu\n",
     "    jax.tools.colab_tpu.setup_tpu()\n",
-    "except KeyError:\n",
+    "except (KeyError, RuntimeError):\n",
     "    print(\"TPU not found, continuing without it.\")"
    ]
   },
@@ -82,8 +82,6 @@
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
-    "import jaxopt\n",
-    "import time\n",
     "\n",
     "from jaxopt import perturbations"
    ]
@@ -711,7 +709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1 (main, Dec 23 2022, 09:28:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/notebooks/perturbed_optimizers/perturbed_optimizers.md
+++ b/docs/notebooks/perturbed_optimizers/perturbed_optimizers.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.15.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -52,7 +52,7 @@ $$y_\varepsilon^*(\theta) = \mathbf{E}[\mathop{\mathrm{arg\,max}}_{y\in \mathcal
 try:
     import jax.tools.colab_tpu
     jax.tools.colab_tpu.setup_tpu()
-except KeyError:
+except (KeyError, RuntimeError):
     print("TPU not found, continuing without it.")
 ```
 
@@ -61,8 +61,6 @@ except KeyError:
 
 import jax
 import jax.numpy as jnp
-import jaxopt
-import time
 
 from jaxopt import perturbations
 ```

--- a/docs/root_finding.rst
+++ b/docs/root_finding.rst
@@ -71,7 +71,7 @@ Scipy wrapper
 
 
 Broyden's method
---------------
+----------------
 
 .. autosummary::
   :toctree: _autosummary


### PR DESCRIPTION
The current TPU activation code was throwing an error when TPUs are not available because new versions of JAX now throws a RuntimeError instead of a KeyError, as we were relying on before.