### PR TITLE
Updated backtracking linesearch, allowed for value_and_grad callable in linesearches

### DIFF
--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -266,7 +266,7 @@ class IterativeSolver(Solver):
     _, state = inputs[0]
     if self.verbose:
       name = self.__class__.__name__
-      jax.debug.print("Sovler: %s, Error: {error}" % name, error=state.error)
+      jax.debug.print("Solver: %s, Error: {error}" % name, error=state.error)
     return state.error > self.tol
 
   def _body_fun(self, inputs):

--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -271,7 +271,7 @@ class BFGS(base.IterativeSolver):
   def __post_init__(self):
     super().__post_init__()
 
-    _, _, self._value_and_grad_with_aux = \
+    _fun_with_aux, _, self._value_and_grad_with_aux = \
       base._make_funs_with_aux(fun=self.fun,
                                value_and_grad=self.value_and_grad,
                                has_aux=self.has_aux)
@@ -280,8 +280,8 @@ class BFGS(base.IterativeSolver):
     unroll = self._get_unroll_option()
     self.linesearch_solver = _setup_linesearch(
         linesearch=self.linesearch,
-        fun=self._value_and_grad_with_aux,
-        value_and_grad=True,
+        fun=_fun_with_aux,
+        value_and_grad=self._value_and_grad_with_aux,
         has_aux=True,
         maxlsiter=self.maxls,
         max_stepsize=self.max_stepsize,

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -421,7 +421,7 @@ class LBFGS(base.IterativeSolver):
   def __post_init__(self):
     super().__post_init__()
 
-    _, _, self._value_and_grad_with_aux = \
+    _fun_with_aux, _, self._value_and_grad_with_aux = \
       base._make_funs_with_aux(fun=self.fun,
                                value_and_grad=self.value_and_grad,
                                has_aux=self.has_aux)
@@ -432,8 +432,8 @@ class LBFGS(base.IterativeSolver):
 
     self.linesearch_solver = _setup_linesearch(
         linesearch=self.linesearch,
-        fun=self._value_and_grad_with_aux,
-        value_and_grad=True,
+        fun=_fun_with_aux,
+        value_and_grad=self._value_and_grad_with_aux,
         has_aux=True,
         maxlsiter=self.maxls,
         max_stepsize=self.max_stepsize,

--- a/jaxopt/_src/lbfgsb.py
+++ b/jaxopt/_src/lbfgsb.py
@@ -583,7 +583,7 @@ class LBFGSB(base.IterativeSolver):
   def __post_init__(self):
     super().__post_init__()
 
-    _, _, self._value_and_grad_with_aux = base._make_funs_with_aux(
+    _fun_with_aux, _, self._value_and_grad_with_aux = base._make_funs_with_aux(
         fun=self.fun,
         value_and_grad=self.value_and_grad,
         has_aux=self.has_aux,
@@ -602,8 +602,8 @@ class LBFGSB(base.IterativeSolver):
     unroll = self._get_unroll_option()
     linesearch_solver = _setup_linesearch(
         linesearch=self.linesearch,
-        fun=self._value_and_grad_with_aux,
-        value_and_grad=True,
+        fun=_fun_with_aux,
+        value_and_grad=self._value_and_grad_with_aux,
         has_aux=True,
         maxlsiter=self.maxls,
         max_stepsize=self.max_stepsize,

--- a/jaxopt/_src/nonlinear_cg.py
+++ b/jaxopt/_src/nonlinear_cg.py
@@ -286,7 +286,7 @@ class NonlinearCG(base.IterativeSolver):
   def __post_init__(self):
     super().__post_init__()
 
-    _, _, self._value_and_grad_with_aux = base._make_funs_with_aux(
+    _fun_with_aux, _, self._value_and_grad_with_aux = base._make_funs_with_aux(
         fun=self.fun, value_and_grad=self.value_and_grad, has_aux=self.has_aux
     )
 
@@ -296,8 +296,8 @@ class NonlinearCG(base.IterativeSolver):
 
     linesearch_solver = _setup_linesearch(
         linesearch=self.linesearch,
-        fun=self._value_and_grad_with_aux,
-        value_and_grad=True,
+        fun=_fun_with_aux,
+        value_and_grad=self._value_and_grad_with_aux,
         has_aux=True,
         maxlsiter=self.maxls,
         max_stepsize=self.max_stepsize,

--- a/jaxopt/_src/zoom_linesearch.py
+++ b/jaxopt/_src/zoom_linesearch.py
@@ -20,6 +20,7 @@ from typing import Any
 from typing import Callable
 from typing import NamedTuple
 from typing import Optional
+from typing import Union
 
 import jax
 from jax import lax
@@ -230,7 +231,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
   """
 
   fun: Callable
-  value_and_grad: bool = False
+  value_and_grad: Union[bool, Callable] = False
   has_aux: bool = False
 
   c1: float = 1e-4


### PR DESCRIPTION
This implements the following:
1. Reduce number of gradient evaluations for BacktrackingLinesearch and generally use value_and_grad as a callable:
  a. In BacktrackingLineSearch, one can pass a callable value_and_grad. In that case, now the armijo and goldstein conditions do not make unnecessary calls to gradients. They only need one call at initialization if the value or the gradient are not provided and one call at the end to output the value and gradient of the parameters found by the linesearch. I added a test to check if the number of calls to the gradients for those linesearches is indeed just 2.
  b. I slightly updated ZoomLineSearch and HagerZhangLinesearches to have signatures using value_and_grad as callables (I simplified a bit HagerZhangLineSearch by the way). I propagated these changes in linesearch_util.py and the algorithms using linesearches (bfgs, lbfgs, lbfgsb, nonlinear_cg).
2. To reduce as much as possible the number of gradient evaluations in the BacktrackingLineSearch I had to do make a few changes and finally decided to make a full pass following some improvements done in the ZoomLinesearch:
  a. The grad and value are computed at the initialization and not anymore in the update. Their values are either the initial values or the final values when the linesearch is done. I added tests to see if the returned stepsize corresponds to the new params, value and grad recorded in the state.
  b. I corrected the handling of NaNs. Previous test was flawed because it checked that state.done was false but what stops the run function is if `state.error >= self.tol` is False which happened as soon as state.error is Nan (I had the same issue when looking at the zoom linesearch). New test passes.
  c. I added a `safe_stepsize` in the BacktrackingLineSearch. The Armijo condition can be satisfied for some `safe_stepsize` which at least ensures a sufficient decrease. If the other condition (i.e. wolfe, strong wolfe, goldstein) is not satisfied, we take this `safe_stepsize` which is better than not taking a stepsize at all or taking a very small one. I added a test for that.
  d. I added some flags to monitor the linesearch behavior if verbose is set to true (just as in the ZoomLineSearch) and added tests.