### PR TITLE
Build and publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: docs
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build-and-deploy:
+    name: "Build and deploy documentation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: Set up Python 3.11
+        uses: "actions/setup-python@v4"
+        with:
+            python-version: 3.11
+            cache: 'pip'
+      - run: pip install -r docs/requirements.txt
+      - name: Build documentation
+        run: cd docs && make html
+      - uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'docs/_build/html'
+          destination-github-username: 'jaxopt'
+          destination-repository-name: 'jaxopt.github.io'
+          user-email: jaxopt@google.com
+          target-branch: main
+          target-directory: dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
             python-version: "${{ matrix.python-version }}"
+            cache: 'pip'
       - name: Install dependencies
         run: |
           set -xe
@@ -59,6 +60,7 @@ jobs:
         uses: "actions/setup-python@v4"
         with:
             python-version: 3.11
+            cache: 'pip'
       - name: Install dependencies
         run: |
           set -xe

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,9 @@
 JAXopt
 ======
 
+.. warning::
+      This is the documentation for the development version of JAXopt.
+
 Hardware accelerated, batchable and differentiable optimizers in
 `JAX <https://github.com/google/jax>`_.
 
@@ -13,7 +16,7 @@ Hardware accelerated, batchable and differentiable optimizers in
 - **Differentiable:** optimization problem solutions can be differentiated with
   respect to their inputs either implicitly or via autodiff of unrolled
   algorithm iterations.
-
+0
 Installation
 ------------
 


### PR DESCRIPTION
This will build the documentation upon every push to master (not on unmerged pull requests) and push to https://jaxopt.github.io/dev/