### PR TITLE
added jax tests and tested in x64, increased maxls for bfgs, lbfgs

### DIFF
--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -120,13 +120,15 @@ class BFGS(base.IterativeSolver):
   has_aux: bool = False
 
   maxiter: int = 500
+  # FIXME: should depend on whether float32 or float64 is used.
+  # Tests should pass in float64 without modifying tol
   tol: float = 1e-3
 
   stepsize: Union[float, Callable] = 0.0
   linesearch: str = "zoom"
   linesearch_init: str = "increase"
   condition: Any = None  # deprecated in v0.8
-  maxls: int = 15
+  maxls: int = 30
   decrease_factor: Any = None  # deprecated in v0.8
   increase_factor: float = 1.5
   max_stepsize: float = 1.0

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -212,6 +212,8 @@ class LBFGS(base.IterativeSolver):
   has_aux: bool = False
 
   maxiter: int = 500
+  # FIXME: should depend on whether float32 or float64 is used.
+  # Tests should pass in float64 without modifying tol
   tol: float = 1e-3
 
   stepsize: Union[float, Callable] = 0.0
@@ -219,7 +221,7 @@ class LBFGS(base.IterativeSolver):
   linesearch_init: str = "increase"
   stop_if_linesearch_fails: bool = False
   condition: Any = None  # deprecated in v0.8
-  maxls: int = 15
+  maxls: int = 30
   decrease_factor: Any = None  # deprecated in v0.8
   increase_factor: float = 1.5
   max_stepsize: float = 1.0

--- a/tests/bfgs_test.py
+++ b/tests/bfgs_test.py
@@ -12,24 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
 from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
 import jax.numpy as jnp
 
-import numpy as onp
-
 from jaxopt import BFGS
 from jaxopt import BacktrackingLineSearch
 from jaxopt import objective
 from jaxopt._src import test_util
-
-
+import numpy as onp
+import scipy.optimize as scipy_opt
 from sklearn import datasets
 
 
+
 N_CALLS = 0
+
+# Uncomment this line to test in x64 
+# jax.config.update('jax_enable_x64', True)
 
 def _bfgs(fun, init, stepsize=1e-3, maxiter=500, tol=1e-3):
   value_and_grad_fun = jax.value_and_grad(fun)
@@ -61,6 +64,40 @@ def _bfgs(fun, init, stepsize=1e-3, maxiter=500, tol=1e-3):
 
   return x
 
+
+def get_fun(name, np):
+
+  def rosenbrock(x):
+    return np.sum(100. * np.diff(x) ** 2 + (1. - x[:-1]) ** 2)
+
+  def himmelblau(p):
+    x, y = p
+    return (x ** 2 + y - 11.) ** 2 + (x + y ** 2 - 7.) ** 2
+
+  def matyas(p):
+    x, y = p
+    return 0.26 * (x ** 2 + y ** 2) - 0.48 * x * y
+
+  def eggholder(p):
+    x, y = p
+    return - (y + 47) * np.sin(np.sqrt(np.abs(x / 2. + y + 47.))) - x * np.sin(
+      np.sqrt(np.abs(x - (y + 47.))))
+
+  def zakharov(x):
+    ii = np.arange(1, len(x) + 1, step=1, dtype=x.dtype)
+    sum1 = (x**2).sum()
+    sum2 = (0.5*ii*x).sum()
+    answer = sum1+sum2**2+sum2**4
+    return answer
+  
+  funs = dict(
+    rosenbrock=rosenbrock,
+    himmelblau=himmelblau,
+    matyas=matyas,
+    eggholder=eggholder,
+    zakharov=zakharov
+  )
+  return funs[name]
 
 class BfgsTest(test_util.JaxoptTestCase):
 
@@ -146,6 +183,80 @@ class BfgsTest(test_util.JaxoptTestCase):
     x1, _ = bfgs.run(x0)
 
     self.assertEqual(N_CALLS, n_iter + 1)
+
+
+  @parameterized.product(
+    fun_init_and_opt=[
+      ('rosenbrock', onp.zeros(2, dtype='float32'), 0.),
+      ('himmelblau', onp.ones(2, dtype='float32'), 0.),
+      ('matyas', onp.ones(2) * 6., 0.),
+      ('eggholder', onp.ones(2) * 100., None),  
+    ],
+  )
+  def test_against_scipy(self, fun_init_and_opt):
+    # Taken from previous jax tests
+    # NOTE(vroulet): Unclear whether lbfgs or bfgs can find true minimum for
+    # eggholder, but they seem to converge to the same solution with current 
+    # implementation and initialization, which is a good check.
+
+    # high precision for faithful checks
+    tol = 1e-15 if jax.config.jax_enable_x64 else 1e-6
+    # jaxopt_opts = dict(maxls=100) if jax.config.jax_enable_x64 else {}
+    fun_name, x0, opt = fun_init_and_opt
+    jnp_fun, onp_fun = get_fun(fun_name, jnp), get_fun(fun_name, onp)
+    jaxopt_res = BFGS(jnp_fun, tol=tol).run(x0).params
+    scipy_res = scipy_opt.minimize(onp_fun, x0, method='BFGS').x
+    if fun_name == 'matyas':
+    # scipy not good for matyas function, compare to true minimum, zero
+      self.assertAllClose(jaxopt_res, jnp.zeros_like(jaxopt_res), check_dtypes=False)
+    elif fun_name == 'eggholder' and jax.config.jax_enable_x64:
+      # NOTE(vroulet): slight issue at high precision here
+      self.assertAllClose(jnp_fun(jaxopt_res), onp_fun(scipy_res),
+                          atol=1e-11, rtol=1e-11, check_dtypes=False)
+    else:
+      self.assertAllClose(jaxopt_res, scipy_res, check_dtypes=False)
+
+    if opt is not None:
+      self.assertAllClose(jnp_fun(jaxopt_res), opt, check_dtypes=False)
+
+  @unittest.skipIf(not jax.config.jax_enable_x64, 'test requires X64')
+  def test_zakharov(self):
+    # Taken from previous jax tests
+    # Function to steep to work without high precision (curiously lbfgs works)
+    x0 = jnp.array([600.0, 700.0, 200.0, 100.0, 90.0, 1e4])
+    fun = get_fun('zakharov', jnp)
+    jaxopt_res = BFGS(fun, tol=1e-16, maxls=50).run(x0).params
+    self.assertAllClose(jaxopt_res, jnp.zeros_like(jaxopt_res))
+    self.assertAllClose(fun(jaxopt_res), 0.)
+
+  def test_minimize_bad_initial_values(self):
+    # Taken from previous jax tests
+    # This test runs deliberately "bad" initial values to test that handling
+    # of failed line search, etc. is the same across implementations
+    initial_value = onp.array([92, 0.001])
+    tol = 1e-6 if jax.config.jax_enable_x64 else 1e-3
+    jnp_fun, onp_fun = get_fun('himmelblau', jnp), get_fun('himmelblau', onp)
+    # Here reuqires higher number of linesearch for jaxopt
+    jaxopt_res = BFGS(jnp_fun, tol=tol).run(initial_value).params
+    scipy_res = scipy_opt.minimize(
+        fun=onp_fun,
+        jac=jax.grad(onp_fun),
+        method='BFGS',
+        x0=initial_value
+    ).x
+    # Scipy and jaxopt converge to different minima so check in function values
+    self.assertAllClose(onp_fun(scipy_res), jnp_fun(jaxopt_res))
+    self.assertAllClose(jnp_fun(jaxopt_res), jnp.asarray(0.))
+
+  def test_steep(self):
+    # Taken from previous jax tests
+    # See jax related issue https://github.com/google/jax/issues/4594
+    n = 2
+    A = jnp.eye(n) * 1e4
+    def fun(x):
+      return jnp.mean((A @ x) ** 2)
+    results = BFGS(fun).run(init_params=jnp.ones(n)).params
+    self.assertAllClose(results, jnp.zeros(n))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding tests from jax to enable moving jax.optimize to using jaxopt, see https://github.com/google/jax/pull/17025. 
Tests failed with previous setup of maximal number of linesearch iterations fixed to 15 and pass by fixing it to 30.
Also, checked if lbfgs and bfgs tests could pass in x64 and added modifications and notes where necessary.

Note: an alternate fix would be to let the zoom linesearch make a step even it has not found a sufficient decrease. The failures were due to the fact that contrarily to scipy we do not "hope for the best" if the linesearch fails. But then this makes the optimizer possibly jump outside the domain of the objective (nan or inf). As long as we print a warning in this case (even without verbose), this could make sense too. Let me know what you prefer.