### PR TITLE
Enhanced zoom linesearch 

### DIFF
--- a/jaxopt/_src/backtracking_linesearch.py
+++ b/jaxopt/_src/backtracking_linesearch.py
@@ -66,7 +66,7 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
     c2: constant strictly less than 1 used by the (strong) Wolfe condition.
     decrease_factor: factor by which to decrease the stepsize during line search
       (default: 0.8).
-    max_stepsize: upper bound on stepsize.
+    max_stepsize: upper bound on stepsize (unused)
 
     maxiter: maximum number of line search iterations.
     tol: tolerance of the stopping criterion.
@@ -87,6 +87,8 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
   c1: float = 1e-4
   c2: float = 0.9
   decrease_factor: float = 0.8
+  # TODO(vroulet): remove max_stepsize argument as it is not used here.
+  # It's handled by the initial guess taken by the linesearch
   max_stepsize: float = 1.0
 
   verbose: int = 0
@@ -167,8 +169,6 @@ class BacktrackingLineSearch(base.IterativeLineSearch):
     Returns:
       (params, state)
     """
-    # Ensure that stepsize does not exceed upper bound.
-    stepsize = jnp.minimum(self.max_stepsize, stepsize)
     num_fun_eval = state.num_fun_eval
     num_grad_eval = state.num_grad_eval
 

--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -100,8 +100,14 @@ class BFGS(base.IterativeSolver):
       backtracking line search (default: 0.8).
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
-    max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    max_stepsize: upper bound on stepsize guess at start of each linesearch run
+      for linesearch_init='increase'.
+      Note that the linesearch is allowed to take a larger stepsize to satisfy
+      curvature conditions.
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run
+      for linesearch_init='increase'.
+      Note that the linesearch is allowed to take a smaller stepsize to satisfy 
+      decrease conditions.
     implicit_diff: whether to enable implicit diff or autodiff of unrolled
       iterations.
     implicit_diff_solve: the linear system solver to use.
@@ -286,7 +292,7 @@ class BFGS(base.IterativeSolver):
         value_and_grad=True,
         has_aux=True,
         maxlsiter=self.maxls,
-        max_stepsize=self.max_stepsize,
+        max_stepsize=None,
         jit=self.jit,
         unroll=unroll,
         verbose=self.verbose,

--- a/jaxopt/_src/hager_zhang_linesearch.py
+++ b/jaxopt/_src/hager_zhang_linesearch.py
@@ -81,7 +81,7 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     c1: constant used by the Wolfe and Approximate Wolfe condition.
     c2: constant strictly less than 1 used by the Wolfe and Approximate Wolfe
       condition.
-    max_stepsize: upper bound on stepsize.
+    max_stepsize: upper bound on stepsize (unused).
 
     maxiter: maximum number of line search iterations.
     tol: tolerance of the stopping criterion.
@@ -103,7 +103,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
   expansion_factor: float = 5.0
   shrinkage_factor: float = 0.66
   approximate_wolfe_threshold = 1e-6
-  max_stepsize: float = 1.0
+  # TODO(vroulet): remove max_stepsize argument as it is not used
+  max_stepsize: float = 1.0 
 
   verbose: int = 0
   jit: base.AutoOrBoolean = "auto"

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -183,8 +183,14 @@ class LBFGS(base.IterativeSolver):
       line search when using backtracking linesearch (default: 0.8).
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
-    max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    max_stepsize: upper bound on stepsize guess at start of each linesearch run
+      for linesearch_init='increase'.
+      Note that the linesearch is allowed to take a larger stepsize to satisfy
+      curvature conditions.
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run
+      for linesearch_init='increase'.
+      Note that the linesearch is allowed to take a smaller stepsize to satisfy 
+      decrease conditions.
     history_size: size of the memory to use.
     use_gamma: whether to initialize the inverse Hessian approximation with
       gamma * I, where gamma is chosen following equation (7.20) of 'Numerical
@@ -438,7 +444,7 @@ class LBFGS(base.IterativeSolver):
         value_and_grad=True,
         has_aux=True,
         maxlsiter=self.maxls,
-        max_stepsize=self.max_stepsize,
+        max_stepsize=None,
         jit=self.jit,
         unroll=unroll,
         verbose=self.verbose,

--- a/jaxopt/_src/lbfgsb.py
+++ b/jaxopt/_src/lbfgsb.py
@@ -261,9 +261,13 @@ class LBFGSB(base.IterativeSolver):
       backtracking line search (default: 0.8).
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
-    max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
-    history_size: size of the memory to use.
+    max_stepsize: upper bound on acceptable stepsize. By default update directions 
+      are defined such that the max_stepsize should be 1. to avoid violating
+      constraints.
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run
+      for linesearch_init='increase'.
+      Note that the linesearch is allowed to take a smaller stepsize to satisfy 
+      decrease conditions.    history_size: size of the memory to use.
     use_gamma: whether to initialize the Hessian approximation with gamma *
       theta, where gamma is chosen following equation (7.20) of 'Numerical
       Optimization' [2]. If use_gamma is set to False, theta is used as
@@ -289,7 +293,7 @@ class LBFGSB(base.IterativeSolver):
   linesearch_init: str = "increase"
   stop_if_linesearch_fails: bool = False
   condition: Any = None  # deprecated in v0.8
-  maxls: int = 20
+  maxls: int = 30
   decrease_factor: Any = None  # deprecated in v0.8
   increase_factor: float = 1.5
   max_stepsize: float = 1.0

--- a/jaxopt/_src/linesearch_util.py
+++ b/jaxopt/_src/linesearch_util.py
@@ -41,7 +41,8 @@ def _setup_linesearch(
         value_and_grad=value_and_grad,
         has_aux=has_aux,
         maxiter=maxlsiter,
-        max_stepsize=max_stepsize,
+        # NOTE(vroulet): max_stepsize has no effect in the solver
+        # max_stepsize=max_stepsize,
         jit=jit,
         unroll=unroll,
         verbose=verbose,
@@ -63,7 +64,8 @@ def _setup_linesearch(
         value_and_grad=value_and_grad,
         has_aux=has_aux,
         maxiter=maxlsiter,
-        max_stepsize=max_stepsize,
+        # NOTE(vroulet): max_stepsize has no effect in the solver
+        # max_stepsize=max_stepsize,
         jit=jit,
         unroll=unroll,
         verbose=verbose,
@@ -95,6 +97,8 @@ def _init_stepsize(
         # Else, we increase a bit the previous one.
         stepsize * increase_factor,
     )
+    # Never guess higher than max_stepsize
+    init_stepsize = jnp.minimum(init_stepsize, max_stepsize)
   else:
     raise ValueError(
         f"Strategy {strategy} not available/tested. "

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -517,11 +517,7 @@ class LbfgsTest(test_util.JaxoptTestCase):
     tol = 1e-15 if jax.config.jax_enable_x64 else 1e-6
     fun_name, x0, opt = fun_init_and_opt
     jnp_fun, onp_fun = get_fun(fun_name, jnp), get_fun(fun_name, onp)
-    jaxopt_options = {}
-    if fun_name == 'zakharov':
-      # zakharov function requires more linesearch iterations
-      jaxopt_options.update(dict(maxls = 50))
-    jaxopt_res = LBFGS(jnp_fun, tol=tol, **jaxopt_options).run(x0).params
+    jaxopt_res = LBFGS(jnp_fun, tol=tol).run(x0).params
     scipy_res = scipy_opt.minimize(onp_fun, x0, method='BFGS').x
     # scipy not good for matyas and zakharov functions, 
     # compare to true minimum, zero

--- a/tests/lbfgsb_test.py
+++ b/tests/lbfgsb_test.py
@@ -29,6 +29,8 @@ import numpy as onp
 
 from sklearn import datasets
 
+# Uncomment this line to test in x64 
+# jax.config.update('jax_enable_x64', True)
 
 class LbfgsbTest(test_util.JaxoptTestCase):
 

--- a/tests/nonlinear_cg_test.py
+++ b/tests/nonlinear_cg_test.py
@@ -26,6 +26,8 @@ from jaxopt import objective
 from jaxopt._src import test_util
 from sklearn import datasets
 
+# Uncomment this line to test in x64 
+jax.config.update('jax_enable_x64', True)
 
 def get_random_pytree():
     key = jax.random.PRNGKey(1213)


### PR DESCRIPTION
Enhanced zoom with 
- earlier stopping: if the interval in which zoom searches is reduced by below some threshold and a sufficient decrease has been found for some stepsize s, just take s. This avoids wasting time finding a curvature condition while a good stepsize ensuring a sufficient decrease has been found. That threshold is now an option. If it appears useful to lower it, I'll document it.
- various actionable messages if the lineseach fails.
- decided to let the linesearch use stepsize even if not giving sufficient decrease with a clear warning, except if that stepsize would lead to NaNs or Infs and it that case the algorithm stays stuck (with a clear message).
- decoupled max_stepsize of initial guess for linesearches to max_stepsize actually taken (documented it). Zoom may use larger stepsize than 1 to satisfy the curvature, however, 1 is a good maximal guess for the stepsize. Such a strategy appeared efficient on the hard zakharov problem. 
- For HagerZhangLinesearch, max_stepsize is actually not used in the algorithm. For Backtracking, a priori the algorithm itself should never increase the stepsize beyond its guess, so I thought it would be better to let max_stepsize be only handled in the initial guess.