### PR TITLE
Enhanced zoom linesearch with earlier stopping, actionable messages, …

### DIFF
--- a/jaxopt/_src/bfgs.py
+++ b/jaxopt/_src/bfgs.py
@@ -101,7 +101,7 @@ class BFGS(base.IterativeSolver):
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
     max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    min_stepsize: lower bound on stepsize guess at start of the linesearch run.
     implicit_diff: whether to enable implicit diff or autodiff of unrolled
       iterations.
     implicit_diff_solve: the linear system solver to use.

--- a/jaxopt/_src/broyden.py
+++ b/jaxopt/_src/broyden.py
@@ -165,7 +165,7 @@ class Broyden(base.IterativeSolver):
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
     max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    min_stepsize: lower bound on stepsize guess at start of the linesearch run.
 
     history_size: size of the memory to use.
     gamma: the initialization of the inverse Jacobian is going to be gamma * I.

--- a/jaxopt/_src/hager_zhang_linesearch.py
+++ b/jaxopt/_src/hager_zhang_linesearch.py
@@ -82,7 +82,7 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
     c1: constant used by the Wolfe and Approximate Wolfe condition.
     c2: constant strictly less than 1 used by the Wolfe and Approximate Wolfe
       condition.
-    max_stepsize: upper bound on stepsize.
+    max_stepsize: upper bound on stepsize (unused).
 
     maxiter: maximum number of line search iterations.
     tol: tolerance of the stopping criterion.
@@ -104,7 +104,8 @@ class HagerZhangLineSearch(base.IterativeLineSearch):
   expansion_factor: float = 5.0
   shrinkage_factor: float = 0.66
   approximate_wolfe_threshold = 1e-6
-  max_stepsize: float = 1.0
+  # TODO(vroulet): remove max_stepsize argument as it is not used
+  max_stepsize: float = 1.0 
 
   verbose: int = 0
   jit: base.AutoOrBoolean = "auto"

--- a/jaxopt/_src/lbfgs.py
+++ b/jaxopt/_src/lbfgs.py
@@ -184,7 +184,7 @@ class LBFGS(base.IterativeSolver):
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
     max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run.
     history_size: size of the memory to use.
     use_gamma: whether to initialize the inverse Hessian approximation with
       gamma * I, where gamma is chosen following equation (7.20) of 'Numerical

--- a/jaxopt/_src/lbfgsb.py
+++ b/jaxopt/_src/lbfgsb.py
@@ -262,7 +262,7 @@ class LBFGSB(base.IterativeSolver):
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.5).
     max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run.
     history_size: size of the memory to use.
     use_gamma: whether to initialize the Hessian approximation with gamma *
       theta, where gamma is chosen following equation (7.20) of 'Numerical
@@ -289,7 +289,7 @@ class LBFGSB(base.IterativeSolver):
   linesearch_init: str = "increase"
   stop_if_linesearch_fails: bool = False
   condition: Any = None  # deprecated in v0.8
-  maxls: int = 20
+  maxls: int = 30
   decrease_factor: Any = None  # deprecated in v0.8
   increase_factor: float = 1.5
   max_stepsize: float = 1.0

--- a/jaxopt/_src/linesearch_util.py
+++ b/jaxopt/_src/linesearch_util.py
@@ -58,12 +58,12 @@ def _setup_linesearch(
         verbose=verbose,
     )
   elif linesearch == "hager-zhang":
+    # NOTE(vroulet): max_stepsize has no effect in HZ
     linesearch_solver = HagerZhangLineSearch(
         fun=fun,
         value_and_grad=value_and_grad,
         has_aux=has_aux,
         maxiter=maxlsiter,
-        max_stepsize=max_stepsize,
         jit=jit,
         unroll=unroll,
         verbose=verbose,

--- a/jaxopt/_src/nonlinear_cg.py
+++ b/jaxopt/_src/nonlinear_cg.py
@@ -91,8 +91,7 @@ class NonlinearCG(base.IterativeSolver):
     increase_factor: factor by which to increase the stepsize during line search
       (default: 1.2).
     max_stepsize: upper bound on stepsize.
-    min_stepsize: lower bound on stepsize.
-
+    min_stepsize: lower bound on stepsize guess at start of each linesearch run.
     implicit_diff: whether to enable implicit diff or autodiff of unrolled
       iterations.
     implicit_diff_solve: the linear system solver to use.
@@ -123,7 +122,7 @@ class NonlinearCG(base.IterativeSolver):
   linesearch: str = "zoom"
   linesearch_init: str = "increase"
   condition: Any = None  # deprecated in v0.8
-  maxls: int = 15
+  maxls: int = 30
   decrease_factor: Any = None  # deprecated in v0.8
   increase_factor: float = 1.2
   max_stepsize: float = 1.0

--- a/jaxopt/_src/zoom_linesearch.py
+++ b/jaxopt/_src/zoom_linesearch.py
@@ -34,29 +34,29 @@ from jaxopt.tree_util import tree_add_scalar_mul
 from jaxopt.tree_util import tree_scalar_mul
 from jaxopt.tree_util import tree_vdot_real
 from jaxopt.tree_util import tree_conj
+from jaxopt.tree_util import tree_l2_norm
 
 # pylint: disable=g-bare-generic
 # pylint: disable=invalid-name
 
 # Flags to print errors, used in tests
 WARNING_PREAMBLE = \
-  "ZoomLineSearchWarning: "
-FLAG_NOT_A_DESCENT_DIRECTION = WARNING_PREAMBLE + \
-  "Provided linesearch direction is not a descent direction. " + \
-  "The linesearch will probably fail."
+  "WARNING: jaxopt.ZoomLineSearch: "
 FLAG_NAN_INF_VALUES = WARNING_PREAMBLE + \
   "NaN or Inf values encountered in function values."
 FLAG_INTERVAL_NOT_FOUND = WARNING_PREAMBLE + \
-  "No interval satisfying curvature condition. " + \
-  "Try increasing maximal stepsize." 
+  "No interval satisfying curvature condition." + \
+  "Consider increasing maximal possible stepsize of the linesearch."
 FLAG_INTERVAL_TOO_SMALL = WARNING_PREAMBLE + \
-  "Length of searched interval has been reduced below machine precision."
+  "Length of searched interval has been reduced below threshold."
 FLAG_CURVATURE_COND_NOT_SATSIFIED = WARNING_PREAMBLE + \
   "Returning stepsize with sufficient decrease " + \
   "but curvature condition not satisfied."
 FLAG_NO_STEPSIZE_FOUND = WARNING_PREAMBLE + \
-  "Linesearch failed, no stepsize satisfying sufficient decrease found. " + \
-  "Try increasing maximal number of linesearch iterations."
+  "Linesearch failed, no stepsize satisfying sufficient decrease found."
+FLAG_NOT_A_DESCENT_DIRECTION = WARNING_PREAMBLE + \
+  "The linesearch failed because the provided direction " + \
+  "is not a descent direction. "
 
 _dot = functools.partial(jnp.dot, precision=lax.Precision.HIGHEST)
 
@@ -128,8 +128,8 @@ def _set_values(cond, candidate, default):
   return jax.tree_util.tree_map(_set_val, candidate, default)
 
 
-def _cond_print(condition, message):
-  jax.lax.cond(condition, lambda _: jax.debug.print(message), lambda _: None, None)
+def _cond_print(condition, message, **kwargs):
+  jax.lax.cond(condition, lambda _: jax.debug.print(message, **kwargs), lambda _: None, None)
 
 
 class ZoomLineSearchState(NamedTuple):
@@ -148,6 +148,8 @@ class ZoomLineSearchState(NamedTuple):
   num_fun_eval: int
   num_grad_eval: int
 
+  decrease_error: float
+  curvature_error: float
   error: float
   done: bool
   failed: bool  # comply to semantic used by other line searches
@@ -213,9 +215,13 @@ class ZoomLineSearch(base.IterativeLineSearch):
       rel_tol_cubic*interval_size (default: 0.2)
     rel_tol_quad: point computed by quadratic interpolation accepted if inside
       rel_tol_quad*interval_size (default: 0.1)
+    interval_threshold: if the size of the interval searched is below this threshold
+      and a sufficient decrease for some stepsize s has been found, 
+      then the linesearch takes s and moves on. (default=5*1e-5, which corresponds 
+      to 15 linesearch iterations for init_stepsize = 1)
     increase_factor: factor to mutliply stepsize at initialization until finding
       interval satisfying curvature condition (default: 2.)
-    max_stepsize: maximal possible stepsize. (default: 2**30)
+    max_stepsize: maximal possible stepsize, (default: 2**maxiter)
     tol: tolerance of the stopping criterion. (default: 0.0)
     maxiter: maximum number of line search iterations. (default: 30)
     verbose: whether to print error on every iteration or not. verbose=True will
@@ -233,13 +239,12 @@ class ZoomLineSearch(base.IterativeLineSearch):
   c3: float = 1e-6
   rel_tol_cubic: float = 0.2
   rel_tol_quad: float = 0.1
+  interval_threshold: float = 1e-6
   increase_factor: float = 2.0
 
   tol: float = 0.0
   maxiter: int = 30
-  # max_stepsize needs to be large enough for the linesearch to be able
-  # to find a good stepsize
-  max_stepsize: float = 2**30
+  max_stepsize: Optional[float] = None
 
   verbose: bool = False
   jit: base.AutoOrBoolean = "auto"
@@ -264,7 +269,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
         value_step - value_init - self.c1 * stepsize * slope_init
     )
     # or an approximate decrease condition, see equation (23) of [2]
-    approx_decrease_error_ = slope_step - (2 * self.c1 - 1.0) * slope_init
+    approx_decrease_error = slope_step - (2 * self.c1 - 1.0) * slope_init
 
     # The classical Armijo condition may fail to be satisfied if we are too
     # close to a minimum, causing the optimizer to fail as explained in [2]
@@ -272,7 +277,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
     # We switch to approximate Wolfe conditions only if we are close enough to
     # the minimizer which is captured by the following criterion.
     delta_values = value_step - value_init - self.c3 * jnp.abs(value_init)
-    approx_decrease_error = jnp.maximum(approx_decrease_error_, delta_values)
+    approx_decrease_error = jnp.maximum(approx_decrease_error, delta_values)
     # We take then the *minimum* of both errors.
     return jnp.minimum(approx_decrease_error, exact_decrease_error)
 
@@ -280,13 +285,18 @@ class ZoomLineSearch(base.IterativeLineSearch):
     # See equation (3.7b) of [1].
     return jnp.abs(slope_step) - self.c2 * jnp.abs(slope_init)
 
-  def _make_safe_step(self, _, state, args, kwargs):
+  def _make_safe_step(self, stepsize, state, args, kwargs):
     safe_stepsize = state.safe_stepsize
-    _cond_print(safe_stepsize == 0.0, FLAG_NO_STEPSIZE_FOUND)
     if self.verbose:
       _cond_print((safe_stepsize > 0.), FLAG_CURVATURE_COND_NOT_SATSIFIED)
+    final_stepsize = jax.lax.cond(
+      safe_stepsize > 0., 
+      lambda safe_stepsize, *_: safe_stepsize,
+      self.failure_diagnostic,
+      safe_stepsize, stepsize, state
+    )
     step = tree_add_scalar_mul(
-        state.params, safe_stepsize, state.descent_direction
+        state.params, final_stepsize, state.descent_direction
     )
     (value_step, aux_step), grad_step = self._value_and_grad_fun_with_aux(
         step, *args, **kwargs
@@ -297,7 +307,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
         grad=grad_step,
         aux=aux_step,
     )
-    return safe_stepsize, new_state
+    return final_stepsize, new_state
 
   def _keep_step(self, stepsize, state, _, __):
     return stepsize, state
@@ -338,16 +348,16 @@ class ZoomLineSearch(base.IterativeLineSearch):
     if self.verbose:
       _cond_print(is_value_nan, FLAG_NAN_INF_VALUES)
 
-    decrease_error_ = self._decrease_error(
+    decrease_error = self._decrease_error(
         new_stepsize, new_value_step, new_slope_step, value_init, slope_init
     )
-    decrease_error = jnp.maximum(decrease_error_, 0.0)
+    decrease_error = jnp.maximum(decrease_error, 0.0)
     decrease_error = jnp.where(
         jnp.isnan(decrease_error), jnp.inf, decrease_error
     )
 
-    curvature_error_ = self._curvature_error(new_slope_step, slope_init)
-    curvature_error = jnp.maximum(curvature_error_, 0.0)
+    curvature_error = self._curvature_error(new_slope_step, slope_init)
+    curvature_error = jnp.maximum(curvature_error, 0.0)
     curvature_error = jnp.where(
         jnp.isnan(curvature_error), jnp.inf, curvature_error
     )
@@ -404,21 +414,21 @@ class ZoomLineSearch(base.IterativeLineSearch):
     # the linesearch is done for either of the two reasons above, we set
     # directly the new parameters, gradient, value and aux to the ones found.
     done = (new_error <= self.tol) | (max_stepsize_reached & ~interval_found)
-    default = [0.0, params_init, value_init, grad_init, aux_init]
+    default = [params_init, value_init, grad_init, aux_init]
     candidate = [
-        new_stepsize,
         new_step,
         new_value_step,
         new_grad_step,
         new_aux_step,
     ]
-    best_stepsize, next_params, next_value, next_grad, next_aux = _set_values(
+    next_params, next_value, next_grad, next_aux = _set_values(
         done, candidate, default
     )
     if self.verbose:
       _cond_print(
         (max_stepsize_reached & ~interval_found),
-        FLAG_INTERVAL_NOT_FOUND + '\n' + FLAG_CURVATURE_COND_NOT_SATSIFIED
+        FLAG_INTERVAL_NOT_FOUND + '\n' 
+        + FLAG_CURVATURE_COND_NOT_SATSIFIED
       )
     max_iter_reached = (iter_num + 1 >= self.maxiter) & (~done)
 
@@ -429,6 +439,8 @@ class ZoomLineSearch(base.IterativeLineSearch):
         grad=next_grad,
         aux=next_aux,
         #
+        decrease_error=decrease_error,
+        curvature_error=curvature_error,
         error=new_error,
         done=done,
         failed=jnp.asarray(max_iter_reached),
@@ -449,7 +461,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
         #
         safe_stepsize=new_safe_stepsize,
     )
-    return base.LineSearchStep(stepsize=best_stepsize, state=new_state)
+    return base.LineSearchStep(stepsize=new_stepsize, state=new_state)
 
   def _zoom_into_interval(self, stepsize, state, args, kwargs):
     """Zoom procedure described in Algorithm 3.6 of [1]."""
@@ -486,7 +498,11 @@ class ZoomLineSearch(base.IterativeLineSearch):
     right = jnp.maximum(high, low)
     cubic_chk = self.rel_tol_cubic * delta
     quad_chk = self.rel_tol_quad * delta
-    threshold = jnp.where((jnp.finfo(delta).bits < 64), 1e-5, 1e-10)
+
+    # Rather large values of threshold compared to machine precision
+    # such that we avoid wasting iterations to satisfy curvature condition
+    # (a stepsize reducing values is taken if it exists when threshold is met)
+    threshold = self.interval_threshold
     too_small_int = delta <= threshold
     if self.verbose:
       _cond_print(too_small_int, FLAG_INTERVAL_TOO_SMALL)
@@ -521,16 +537,16 @@ class ZoomLineSearch(base.IterativeLineSearch):
     if self.verbose:
       _cond_print(is_value_nan, FLAG_NAN_INF_VALUES)
 
-    decrease_error_ = self._decrease_error(
+    decrease_error = self._decrease_error(
         middle, value_middle, slope_middle, value_init, slope_init
     )
-    decrease_error = jnp.maximum(decrease_error_, 0.0)
+    decrease_error = jnp.maximum(decrease_error, 0.0)
     decrease_error = jnp.where(
         jnp.isnan(decrease_error), jnp.inf, decrease_error
     )
 
-    curvature_error_ = self._curvature_error(slope_middle, slope_init)
-    curvature_error = jnp.maximum(curvature_error_, 0.0)
+    curvature_error = self._curvature_error(slope_middle, slope_init)
+    curvature_error = jnp.maximum(curvature_error, 0.0)
     curvature_error = jnp.where(
         jnp.isnan(curvature_error), jnp.inf, curvature_error
     )
@@ -540,14 +556,14 @@ class ZoomLineSearch(base.IterativeLineSearch):
     # If the new point satisfies at least the decrease error we keep it in case
     # the curvature error cannot be satisfied. We take the largest possible one
     safe_decrease = decrease_error <= self.tol
-    new_safe_stepsize_ = jnp.where(safe_decrease, middle, safe_stepsize)
-    new_safe_stepsize = jnp.maximum(new_safe_stepsize_, safe_stepsize)
+    new_safe_stepsize = jnp.where(safe_decrease, middle, safe_stepsize)
+    new_safe_stepsize = jnp.maximum(new_safe_stepsize, safe_stepsize)
 
     # If both armijo and curvature conditions are satisfied, we are done.
     done = new_error <= self.tol
-    default = [0.0, params_init, value_init, grad_init, aux_init]
-    candidate = [middle, step, value_middle, grad_step, aux_step]
-    best_stepsize, next_params, next_value, next_grad, next_aux = _set_values(
+    default = [params_init, value_init, grad_init, aux_init]
+    candidate = [step, value_middle, grad_step, aux_step]
+    next_params, next_value, next_grad, next_aux = _set_values(
         new_error <= self.tol, candidate, default
     )
 
@@ -585,9 +601,15 @@ class ZoomLineSearch(base.IterativeLineSearch):
         [high, value_high],
         [low, value_low],
     )
-
-    max_iter_reached = (iter_num + 1 >= self.maxiter) & (~done)
-
+    # We stop if the searched interval is reduced below machine precision 
+    # and we already have found a positive stepsize ensuring sufficient
+    # decrease. If no stepsize with sufficient decrease has been found, 
+    # we keep going on (some extremely steep functions require very small
+    # stepsizes, see zakharov test in lbfgs_test.py)
+    max_iter_reached = (iter_num + 1 >= self.maxiter)
+    presumably_failed = jnp.asarray(max_iter_reached) | \
+      (too_small_int & (new_safe_stepsize > 0.))
+    failed = presumably_failed & ~done
     new_state = state._replace(
         iter_num=iter_num + 1,
         params=next_params,
@@ -595,9 +617,11 @@ class ZoomLineSearch(base.IterativeLineSearch):
         grad=next_grad,
         aux=next_aux,
         #
+        decrease_error=decrease_error,
+        curvature_error=curvature_error,
         error=new_error,
         done=done,
-        failed=jnp.asarray(max_iter_reached),
+        failed=failed,
         #
         low=new_low,
         value_low=new_value_low,
@@ -610,7 +634,7 @@ class ZoomLineSearch(base.IterativeLineSearch):
         #
         safe_stepsize=new_safe_stepsize,
     )
-    return base.LineSearchStep(stepsize=best_stepsize, state=new_state)
+    return base.LineSearchStep(stepsize=middle, state=new_state)
 
   def init_state(
       self,
@@ -666,8 +690,6 @@ class ZoomLineSearch(base.IterativeLineSearch):
 
     slope = tree_vdot_real(tree_conj(grad), descent_direction)
 
-    _cond_print(slope > 0, FLAG_NOT_A_DESCENT_DIRECTION)
-
     return ZoomLineSearchState(
         iter_num=jnp.asarray(0),
         params=params,
@@ -679,6 +701,8 @@ class ZoomLineSearch(base.IterativeLineSearch):
         slope_init=slope,
         descent_direction=descent_direction,
         #
+        decrease_error=jnp.asarray(jnp.inf),
+        curvature_error=jnp.asarray(jnp.inf),
         error=jnp.asarray(jnp.inf),
         done=jnp.asarray(False),
         failed=jnp.asarray(False),
@@ -701,15 +725,6 @@ class ZoomLineSearch(base.IterativeLineSearch):
         num_fun_eval=num_fun_eval,
         num_grad_eval=num_grad_eval,
     )
-
-  def _cond_fun(self, inputs):
-    # Stop the linesearch according to done rather than the error as one may
-    # reach the maximal stepsize and no decrease of the curvature error may be
-    # possible.
-    _, state = inputs[0]
-    if self.verbose:
-      jax.debug.print("Solver: ZoomLineSearch, Error: {error}", error=state.error)
-    return ~state.done
 
   def update(
       self,
@@ -767,10 +782,10 @@ class ZoomLineSearch(base.IterativeLineSearch):
     )
 
     anticipated_num_func_grad_calls = jnp.array(
-      (new_state_.failed) & (new_state_.iter_num == self.maxiter)
+      new_state_.failed
     ).astype(base.NUM_EVAL_DTYPE)
     best_stepsize, new_state = cond(
-        (new_state_.failed) & (new_state_.iter_num == self.maxiter),
+        new_state_.failed,
         self._make_safe_step,
         self._keep_step,
         best_stepsize_,
@@ -786,9 +801,89 @@ class ZoomLineSearch(base.IterativeLineSearch):
 
     return base.LineSearchStep(stepsize=best_stepsize, state=new_state)
 
+  def _cond_fun(self, inputs):
+    # Stop the linesearch according to done or failed rather than the error as one may
+    # reach the maximal stepsize and no decrease of the curvature error may be
+    # possible or the searched interval has been reduced too much.
+    stepsize, state = inputs[0]
+    if self.verbose:
+      self._log_info(stepsize, state)
+    return ~(state.done | state.failed)
+
+  def _log_info(self, stepsize, state):
+    jax.debug.print(
+        "INFO: jaxopt.ZoomLineSearch: " + \
+        "Iter: {iter}, " + \
+        "Stepsize: {stepsize}, " + \
+        "Decrease error: {decrease_error}, " + \
+        "Curvature error: {curvature_error}",
+        iter=state.iter_num,
+        stepsize=stepsize,
+        decrease_error=state.decrease_error,
+        curvature_error=state.curvature_error
+    )
+
+  def failure_diagnostic(self, safe_stepsize, stepsize, state):
+    jax.debug.print(FLAG_NO_STEPSIZE_FOUND)
+    self._log_info(stepsize, state)
+
+    slope_init = state.slope_init
+    is_descent_dir = slope_init < 0.
+    _cond_print(
+      ~is_descent_dir,
+      FLAG_NOT_A_DESCENT_DIRECTION + \
+      "The slope (={slope_init}) at stepsize=0 should be negative",
+      slope_init=slope_init
+    )
+    _cond_print(
+      is_descent_dir,
+      WARNING_PREAMBLE + \
+      "Consider augmenting the maximal number of linesearch iterations."
+    )
+    eps = jnp.finfo(stepsize).eps
+    below_eps = stepsize < eps
+    _cond_print(
+      below_eps & is_descent_dir,
+      WARNING_PREAMBLE + \
+      "Computed stepsize (={stepsize}) " + \
+      "is below machine precision (={eps}), " +\
+      "consider passing to higher precision like x64, using " +\
+      "jax.config.update('jax_enable_x64', True).",
+      stepsize=stepsize, 
+      eps=eps
+    )
+    abs_slope_init = jnp.abs(slope_init)
+    high_slope = abs_slope_init > 1e16
+    _cond_print(
+      high_slope & is_descent_dir,
+      WARNING_PREAMBLE + \
+      "Very large absolute slope at stepsize=0. (|slope|={abs_slope_init}). " + \
+      "The objective is badly conditioned. " + \
+      "Consider reparameterizing objective (e.g., normalizing parameters) " + \
+      "or finding a better guess for the initial parameters for the solver.",
+      abs_slope_init=abs_slope_init
+    )
+    outside_domain = jnp.isinf(state.decrease_error)
+    _cond_print(
+      outside_domain,
+      WARNING_PREAMBLE + \
+      "Cannot even make a step without getting Inf or Nan. " + \
+      "The linesearch won't make a step and the optimizer is stuck."
+    )
+    _cond_print(
+      ~outside_domain,
+      WARNING_PREAMBLE + \
+      "Making an unsafe step, not decreasing enough the objective. " + \
+      "Convergence of the solver is compromised as it does not reduce values."
+    )
+    final_stepsize = jnp.where(outside_domain, safe_stepsize, stepsize)
+    return final_stepsize
+
   def __post_init__(self):
     self._fun_with_aux, _, self._value_and_grad_fun_with_aux = (
         _make_funs_with_aux(
             self.fun, value_and_grad=self.value_and_grad, has_aux=self.has_aux
         )
     )
+    if not self.max_stepsize:
+      self.max_stepsize = float(2**self.maxiter)

--- a/tests/bfgs_test.py
+++ b/tests/bfgs_test.py
@@ -200,7 +200,7 @@ class BfgsTest(test_util.JaxoptTestCase):
     # implementation and initialization, which is a good check.
 
     # high precision for faithful checks
-    tol = 1e-15 if jax.config.jax_enable_x64 else 1e-6
+    tol = 1e-15 if jax.config.jax_enable_x64 else 1e-7
     # jaxopt_opts = dict(maxls=100) if jax.config.jax_enable_x64 else {}
     fun_name, x0, opt = fun_init_and_opt
     jnp_fun, onp_fun = get_fun(fun_name, jnp), get_fun(fun_name, onp)

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -514,14 +514,10 @@ class LbfgsTest(test_util.JaxoptTestCase):
     # NOTE(vroulet): Unclear whether lbfgs or bfgs can find true minimum for
     # eggholder, but they seem to converge to the same solution with current 
     # implementation and initialization, which is a good check.
-    tol = 1e-15 if jax.config.jax_enable_x64 else 1e-6
+    tol = 1e-15 if jax.config.jax_enable_x64 else 1e-7
     fun_name, x0, opt = fun_init_and_opt
     jnp_fun, onp_fun = get_fun(fun_name, jnp), get_fun(fun_name, onp)
-    jaxopt_options = {}
-    if fun_name == 'zakharov':
-      # zakharov function requires more linesearch iterations
-      jaxopt_options.update(dict(maxls = 50))
-    jaxopt_res = LBFGS(jnp_fun, tol=tol, **jaxopt_options).run(x0).params
+    jaxopt_res = LBFGS(jnp_fun, tol=tol).run(x0).params
     scipy_res = scipy_opt.minimize(onp_fun, x0, method='BFGS').x
     # scipy not good for matyas and zakharov functions, 
     # compare to true minimum, zero

--- a/tests/lbfgsb_test.py
+++ b/tests/lbfgsb_test.py
@@ -29,6 +29,8 @@ import numpy as onp
 
 from sklearn import datasets
 
+# Uncomment this line to test in x64 
+# jax.config.update('jax_enable_x64', True)
 
 class LbfgsbTest(test_util.JaxoptTestCase):
 

--- a/tests/nonlinear_cg_test.py
+++ b/tests/nonlinear_cg_test.py
@@ -26,6 +26,8 @@ from jaxopt import objective
 from jaxopt._src import test_util
 from sklearn import datasets
 
+# Uncomment this line to test in x64 
+# jax.config.update('jax_enable_x64', True)
 
 def get_random_pytree():
     key = jax.random.PRNGKey(1213)
@@ -149,8 +151,10 @@ class NonlinearCGTest(test_util.JaxoptTestCase):
                            maxls=3, method=method, linesearch=linesearch)
     sol_C, _ = solver_C.run(z0)
     sol_R, _ = solver_R.run(C2R(z0))
-
-    self.assertArraysAllClose(sol_C, R2C(sol_R))
+    # NOTE(vroulet): there is a slight loss of precision between real
+    # and complex cases (observable for any linesearch with jax.enable_x64
+    tol = 5*1e-15 if jax.config.jax_enable_x64 else 5*1e-6
+    self.assertArraysAllClose(sol_C, R2C(sol_R), atol=tol, rtol=tol)
 
 
 if __name__ == '__main__':

--- a/tests/zoom_linesearch_test.py
+++ b/tests/zoom_linesearch_test.py
@@ -36,7 +36,8 @@ from sklearn import datasets
 
 
 # pylint: disable=invalid-name
-
+# Uncomment the line below in order to run in float64.
+# jax.config.update("jax_enable_x64", True)
 
 class ZoomLinesearchTest(test_util.JaxoptTestCase):
   """Tests for ZoomLineSearch."""
@@ -216,7 +217,7 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
         w_init, descent_dir, stepsize, fun_, jax.grad(fun_), state
     )
 
-  def test_failure_cases(self):
+  def test_failure_descent_direction(self):
     # See gh-7475
 
     # For this f and p, starting at a point on axis 0, the strong Wolfe
@@ -225,44 +226,56 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
     def fun(x):
       return jnp.dot(x, x)
 
-    def fun_der(x):
-      return 2.0 * x
-
-    c2 = 0.5
     p = jnp.array([1.0, 0.0])
-
-    # 1. Test that the line search fails for p not a descent direction
     x = 60 * p
-    ls = ZoomLineSearch(fun, c2=c2, maxiter=10)
+
+    # Test that the line search fails for p not a descent direction
+    # For high maxiter, still finds a decrease error because of 
+    # the approximate Wolfe condition so we reduced maxiter
+    ls = ZoomLineSearch(fun, c2=0.5, maxiter=18)
     stdout = io.StringIO()
     with redirect_stdout(stdout):
       s, state = ls.run(init_stepsize=1.0, params=x, descent_direction=p)
-    self._check_step_in_state(x, p, s, fun, fun_der, state)
+    self._check_step_in_state(x, p, s, fun, jax.grad(fun), state)
     # Check that we were not able to make a step or an infinitesimal one
-    self.assertTrue(s == 0.)
+    self.assertLess(s, 1e-5)
     self.assertTrue(FLAG_NOT_A_DESCENT_DIRECTION in stdout.getvalue())
     self.assertTrue(FLAG_NO_STEPSIZE_FOUND in stdout.getvalue())
 
-    # 2. Test that the line search fails if the maximum stepsize is too small
-    # Here, smallest s satisfying strong Wolfe conditions for c2=0.5 is 30
+  def test_failure_too_small_max_stepsize(self):
+    def fun(x):
+      return jnp.dot(x, x)
+
+    p = jnp.array([1.0, 0.0])
     x = -60 * p
-    ls = ZoomLineSearch(fun, c2=c2, max_stepsize=10, verbose=True)
+
+    # Test that the line search fails if the maximum stepsize is too small
+    # Here, smallest s satisfying strong Wolfe conditions for c2=0.5 is 30
+    ls = ZoomLineSearch(fun, c2=0.5, max_stepsize=10, verbose=True)
     stdout = io.StringIO()
     with redirect_stdout(stdout):
       s, state = ls.run(init_stepsize=1.0, params=x, descent_direction=p)
-    self._check_step_in_state(x, p, s, fun, fun_der, state)
+    self._check_step_in_state(x, p, s, fun, jax.grad(fun), state)
     # Check that we still made a step
     self.assertTrue(s == 10.0)
     self.assertTrue(FLAG_INTERVAL_NOT_FOUND in stdout.getvalue())
     self.assertTrue(FLAG_CURVATURE_COND_NOT_SATSIFIED in stdout.getvalue())
 
-    # 3. s=30 will only be tried on the 6th iteration, so this fails because
+  def test_failure_not_enough_iter(self):
+    def fun(x):
+      return jnp.dot(x, x)
+
+    p = jnp.array([1.0, 0.0])
+    x = -60 * p
+
+    c2 = 0.5
+    # s=30 will only be tried on the 6th iteration, so this fails because
     # the maximum number of iterations is reached.
     ls = ZoomLineSearch(fun, c2=c2, maxiter=5, verbose=True)
     stdout = io.StringIO()
     with redirect_stdout(stdout):
       s, state = ls.run(init_stepsize=1.0, params=x, descent_direction=p)
-    self._check_step_in_state(x, p, s, fun, fun_der, state)
+    self._check_step_in_state(x, p, s, fun, jax.grad(fun), state)
     # Check that we still made a step
     self.assertTrue(s == 16.0)
     self.assertTrue(state.failed)
@@ -272,10 +285,11 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
     # Check if it works normally
     ls = ZoomLineSearch(fun, c2=c2)
     s, state = ls.run(init_stepsize=1.0, params=x, descent_direction=p)
-    self._assert_line_conds(x, p, s, fun, fun_der, c1=ls.c1, c2=c2)
-    self._check_step_in_state(x, p, s, fun, fun_der, state)
+    self._assert_line_conds(x, p, s, fun, jax.grad(fun), c1=ls.c1, c2=c2)
+    self._check_step_in_state(x, p, s, fun, jax.grad(fun), state)
     self.assertTrue(s >= 30.0)
 
+  def test_failure_flat_fun(self):
     # Check failure for a very flat function
     def fun_flat(x):
       return jnp.exp(-1 / x**2)
@@ -289,13 +303,14 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
       ls.run(init_stepsize=1.0, params=x)
     self.assertTrue(FLAG_INTERVAL_TOO_SMALL in stdout.getvalue())
 
+  def test_failure_inf_value(self):
     # Check behavior for inf/nan values
     def fun_inf(x):
       return jnp.log(x)
 
     x = 1.0
     p = -2.0
-    ls = ZoomLineSearch(fun_inf, verbose=True, jit=False)
+    ls = ZoomLineSearch(fun_inf, verbose=True)
     stdout = io.StringIO()
     with redirect_stdout(stdout):
       ls.run(init_stepsize=1.0, params=x, descent_direction=p)
@@ -423,6 +438,4 @@ class ZoomLinesearchTest(test_util.JaxoptTestCase):
 
 
 if __name__ == "__main__":
-  # Uncomment the line below in order to run in float64.
-  # jax.config.update("jax_enable_x64", True)
   absltest.main()


### PR DESCRIPTION
I discussed with Brendan McMahan and Ryan McKenna, who are using JAXOpt and especially LBFGS. They pointed out some potential improvements. The main one being the actionable messages. I inferred an earlier stopping in case the interval is too small from the colab they shared.

So this PR is about enhancing zoom with
- Earlier stopping: if the interval in which zoom searches is reduced by below some threshold and a sufficient decrease has been found for some stepsize s, just take s. This avoids wasting time finding a curvature condition while a good stepsize ensuring a sufficient decrease has been found. That threshold is now an option. If it appears useful to lower it, I'll document it.
- Various actionable messages if the lineseach fails.
- Decided to let the linesearch use stepsize even if not giving sufficient decrease with a clear warning, except if that stepsize would lead to NaNs or Infs and it that case the algorithm stays stuck (with a clear message).

I've also done the following (can move to another PR if you want).
- Decoupled max_stepsize of initial guess for linesearches to max_stepsize actually taken (documented it). Zoom may use larger stepsize than 1 to satisfy the curvature, however, 1 is a good maximal guess for the stepsize. Such a strategy appeared efficient on the hard zakharov problem.
- For HagerZhangLinesearch, max_stepsize is actually not used in the algorithm. For Backtracking, a priori the algorithm itself should never increase the stepsize beyond its guess, so I thought it would be better to let max_stepsize be only handled in the initial guess.