### PR TITLE
fix deprecated load_boston from scikitlearn

### DIFF
--- a/examples/constrained/nmf.py
+++ b/examples/constrained/nmf.py
@@ -101,7 +101,7 @@ def main(argv):
   del argv
 
   # Prepare data.
-  X, _ = datasets.load_boston(return_X_y=True)
+  X, _ = datasets.load_diabetes(return_X_y=True)
   X = jnp.sqrt(X ** 2)
 
   n_samples = X.shape[0]

--- a/examples/implicit_diff/lasso_implicit_diff.py
+++ b/examples/implicit_diff/lasso_implicit_diff.py
@@ -79,7 +79,7 @@ def main(argv):
   print("Unrolling:", FLAGS.unrolling)
 
   # Prepare data.
-  X, y = datasets.load_boston(return_X_y=True)
+  X, y = datasets.load_diabetes(return_X_y=True)
   X = preprocessing.normalize(X)
   # data = (X_tr, X_val, y_tr, y_val)
   data = model_selection.train_test_split(X, y, test_size=0.33, random_state=0)

--- a/examples/implicit_diff/ridge_reg_implicit_diff.py
+++ b/examples/implicit_diff/ridge_reg_implicit_diff.py
@@ -71,7 +71,7 @@ def main(argv):
   del argv
 
   # Prepare data.
-  X, y = datasets.load_boston(return_X_y=True)
+  X, y = datasets.load_diabetes(return_X_y=True)
   X = preprocessing.normalize(X)
   # data = (X_tr, X_val, y_tr, y_val)
   data = model_selection.train_test_split(X, y, test_size=0.33, random_state=0)


### PR DESCRIPTION
`load_boston` has been removed from scikit-learn since version 1.2 for ethical reasons.
This should fix the issue for the docs to build.