### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*.{py,rst,md,yml}]
+indent_style = space
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+max_line_length = 79
+indent_size = 2
+
+[*.rst]
+max_line_length = 79
+indent_size = 2
+
+[*.md]
+max_line_length = 79
+indent_size = 2
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This file helps non-Googler contributors who have their editors set up
differently for different projects.  Most modern editors will
automatically use the Google style when they see this file:
* (most importantly) 2 character indent size,
* 79 character maximum line length,
* spaces instead of tabs,
* linux line endings, and
* no extraneous whitespace.