### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,10 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="optimization, root finding, implicit differentiation, jax",
-    requires_python=">=3.8",
+    requires_python=">=3.9",
 )


### PR DESCRIPTION
Jax no longer supports 3.8 (and will drop 3.9 in July according to their [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html)).