### PR TITLE
Fix tests

### DIFF
--- a/tests/bfgs_test.py
+++ b/tests/bfgs_test.py
@@ -187,8 +187,8 @@ class BfgsTest(test_util.JaxoptTestCase):
 
   @parameterized.product(
     fun_init_and_opt=[
-      ('rosenbrock', onp.zeros(2, dtype='float32'), 0.),
-      ('himmelblau', onp.ones(2, dtype='float32'), 0.),
+      ('rosenbrock', onp.zeros(2), 0.),
+      ('himmelblau', onp.ones(2), 0.),
       ('matyas', onp.ones(2) * 6., 0.),
       ('eggholder', onp.ones(2) * 100., None),  
     ],

--- a/tests/isotonic_test.py
+++ b/tests/isotonic_test.py
@@ -48,8 +48,8 @@ class IsotonicPavTest(test_util.JaxoptTestCase):
     y_min = y_sort[2]
     y_max = y_sort[n-5]
     output = isotonic_l2_pav(y, y_min=y_min, y_max=y_max, increasing=increasing)
-    output_sklearn = jnp.array(isotonic.isotonic_regression(y, y_min=y_min,
-     y_max=y_max, increasing=increasing))
+    output_sklearn = jnp.array(isotonic.isotonic_regression(y, y_min=y_min.item(),
+     y_max=y_max.item(), increasing=increasing))
     self.assertArraysAllClose(output, output_sklearn)
 
   @parameterized.product(increasing=[True, False])

--- a/tests/lbfgs_test.py
+++ b/tests/lbfgs_test.py
@@ -409,20 +409,17 @@ class LbfgsTest(test_util.JaxoptTestCase):
       x0 = (onp.asarray(beta_init)), method='BFGS'
     ).x
 
-
-    #jaxopt
+    # using jaxopt
     solver = LBFGS(fun=binary_logit_log_likelihood_jax, maxiter=100,
                    linesearch="zoom", maxls=10, tol=1e-12)
     jaxopt_res = solver.run(beta_init, y, x).params
-    if jax.config.jax_enable_x64:
-      # NOTE(vroulet): simply testing in function values at high precision
-      scipy_val = binary_logit_log_likelihood(scipy_res,
-                                              onp.asarray(y),
-                                              onp.asarray(x))
-      jaxopt_val = binary_logit_log_likelihood(jaxopt_res, y, x)
-      self.assertArraysAllClose(scipy_val, jaxopt_val)
-    else:
-      self.assertArraysAllClose(scipy_res, jaxopt_res)
+
+    # comparison
+    scipy_val = binary_logit_log_likelihood(scipy_res,
+                                            onp.asarray(y),
+                                            onp.asarray(x))
+    jaxopt_val = binary_logit_log_likelihood(jaxopt_res, y, x)
+    self.assertArraysAllClose(scipy_val, jaxopt_val)
     
 
   @parameterized.product(linesearch=['zoom', 'backtracking', 'hager-zhang'])
@@ -502,8 +499,8 @@ class LbfgsTest(test_util.JaxoptTestCase):
 
   @parameterized.product(
     fun_init_and_opt=[
-      ('rosenbrock', onp.zeros(2, dtype='float32'), 0.),
-      ('himmelblau', onp.ones(2, dtype='float32'), 0.),
+      ('rosenbrock', onp.zeros(2), 0.),
+      ('himmelblau', onp.ones(2), 0.),
       ('matyas', onp.ones(2) * 6., 0.),
       ('eggholder', onp.ones(2) * 100., None),  
       ('zakharov', onp.array([600.0, 700.0, 200.0, 100.0, 90.0, 1e4]), 0.),


### PR DESCRIPTION
Tests appeared broken in the main branch because of updates in scikit-learn and scipy.
This fixes several issues by (i) letting scipy run with default precision when testing bfgs/lbfgs, (ii) testing optimum in function values for the lbfgs tests on binary logistic regression, (iii) fixing the argument for the isotonic pav test.
