### PR TITLE
fix lasso with scalar l1reg

### DIFF
--- a/jaxopt/_src/prox.py
+++ b/jaxopt/_src/prox.py
@@ -70,7 +70,7 @@ def prox_lasso(x: Any,
   if l1reg is None:
     l1reg = 1.0
 
-  if type(l1reg) == float:
+  if jnp.isscalar(l1reg):
     l1reg = tree_util.tree_map(lambda y: l1reg*jnp.ones_like(y), x)
 
   def fun(u, v): return jnp.sign(u) * jax.nn.relu(jnp.abs(u) - v * scaling)

--- a/tests/prox_test.py
+++ b/tests/prox_test.py
@@ -87,6 +87,13 @@ class ProxTest(test_util.JaxoptTestCase):
     got = prox.prox_lasso(x, alpha)
     self.assertArraysAllClose(jnp.array(expected), jnp.array(got))
 
+    # test that works when regularizer is float and prox jit compiled
+    got = jax.jit(prox.prox_lasso)(x, 0.5)
+    expected0 = [self._prox_l1(x[0][i], 0.5) for i in range(len(x[0]))]
+    expected1 = [self._prox_l1(x[1][i], 0.5) for i in range(len(x[0]))]
+    expected = (jnp.array(expected0), jnp.array(expected1))
+    self.assertArraysAllClose(jnp.array(expected), jnp.array(got))
+
   def _prox_enet(self, x, lam, gamma):
     return (1.0 / (1.0 + lam * gamma)) * self._prox_l1(x, lam)
 


### PR DESCRIPTION
First of all, thanks for the very nice package.

In this PR I am generalizing the behavior of `jaxopt.prox.prox_lasso` to handle scalar input when jit-compiled. 

In particular the following used to result in an exception.

```python
import numpy as np
from jaxopt import prox
import jax

rng = np.random.RandomState(0)
x = (rng.rand(20) * 2 - 1, rng.rand(20) * 2 - 1)
jax.jit(prox.prox_lasso)(x, 0.5)
```

Best regards,
Edoardo