### PR TITLE
Avoid use of deprecated xla_bridge.get_backend().platform

### DIFF
--- a/jaxopt/_src/test_util.py
+++ b/jaxopt/_src/test_util.py
@@ -244,7 +244,7 @@ def tolerance(dtype, tol=None):
 
 
 def device_under_test():
-  return jax.lib.xla_bridge.get_backend().platform
+  return jax.default_backend()
 
 
 def _assert_numpy_allclose(a, b, atol=None, rtol=None, err_msg=''):


### PR DESCRIPTION
xla_bridge.get_backend is deprecated, and the public API for this is jax.default_backend(). This is a drop-in replacement with no change of behavior.