### PR TITLE
Loosen lbfgsb_test Rosenbrock tolerance to 1.5e-3

### DIFF
--- a/tests/lbfgsb_test.py
+++ b/tests/lbfgsb_test.py
@@ -100,7 +100,7 @@ class LbfgsbTest(test_util.JaxoptTestCase):
     x, _ = lbfgsb.run(x0, bounds=(lower, upper))
 
     # the Rosenbrock function is zero at its minimum
-    self.assertLessEqual(fun(x), 1e-3)
+    self.assertLessEqual(fun(x), 1.5e-3)
 
   @parameterized.parameters(
       ((0., -5., 0), (2., 0., 1)),


### PR DESCRIPTION
Update tolerance - a recent XLA:CPU change to strength reduction of batched vector vector products made this fail due to fp noise.