### PR TITLE
docs: add OptStep API reference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,14 @@
 API at a glance
 ===============
 
+Base containers
+---------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.OptStep
+
 Optimization
 ------------
 
@@ -180,4 +188,3 @@ Tree utilities
     jaxopt.tree_util.tree_sum
     jaxopt.tree_util.tree_l2_norm
     jaxopt.tree_util.tree_zeros_like
-

--- a/jaxopt/_src/base.py
+++ b/jaxopt/_src/base.py
@@ -46,6 +46,12 @@ ArrayPair = Tuple[jnp.ndarray, jnp.ndarray]
 NUM_EVAL_DTYPE = 'int32'
 
 class OptStep(NamedTuple):
+  """Container returned by solvers.
+
+  Attributes:
+    params: solution parameters returned by the solver.
+    state: solver-specific state associated with ``params``.
+  """
   params: Any
   state: Any
 


### PR DESCRIPTION
## Summary

- Adds `jaxopt.OptStep` to the API autosummary so solver return types can link to a generated reference page.
- Adds a short docstring for the `OptStep` container fields.

Fixes #251.

## Testing

- `python3.12 -m compileall -q jaxopt/_src/base.py`
- `git diff --check`
- Temporary Python 3.12 venv smoke test with `jax`/`jaxlib`: imported `jaxopt.OptStep` and `jaxopt.base.OptStep`, verified they are the same object, and constructed an `OptStep`.

I did not run the full Sphinx docs build locally because `docs/requirements.txt` installs the full docs stack, including TensorFlow/Flax, for this small autosummary/docstring change.