### PR TITLE
docs: add scipy least squares API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -98,6 +98,8 @@ Nonlinear least squares
 
     jaxopt.GaussNewton
     jaxopt.LevenbergMarquardt
+    jaxopt.ScipyLeastSquares
+    jaxopt.ScipyBoundedLeastSquares
 
 Root finding
 ------------

--- a/docs/nonlinear_least_squares.rst
+++ b/docs/nonlinear_least_squares.rst
@@ -98,3 +98,17 @@ parameters:
 
 where :math:`\mathbf{J}` is the Jacobian of the residual function w.r.t.
 parameters and :math:`\mu` is the damping parameter.
+
+SciPy wrappers
+--------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    jaxopt.ScipyLeastSquares
+    jaxopt.ScipyBoundedLeastSquares
+
+For users who need SciPy's ``least_squares`` implementation with PyTree and
+implicit differentiation support, :class:`jaxopt.ScipyLeastSquares` wraps
+unconstrained nonlinear least squares problems and
+:class:`jaxopt.ScipyBoundedLeastSquares` handles problems with box constraints.


### PR DESCRIPTION
Fixes #184.

## What
- Add `jaxopt.ScipyLeastSquares` and `jaxopt.ScipyBoundedLeastSquares` to the API overview under nonlinear least squares.
- Add a short SciPy wrappers section to the nonlinear least squares docs so the classes have visible autosummary entries.

## Testing
- `git diff --check`
- Temporary venv smoke test importing `jaxopt.ScipyLeastSquares` and `jaxopt.ScipyBoundedLeastSquares` with `jax`, `jaxlib`, and `scipy` installed.

The full Sphinx docs build was not run locally because the docs requirements install the full documentation stack, including TensorFlow/Flax.