### PR TITLE
docs: clarify OSQP empty constraints

### DIFF
--- a/docs/quadratic_programming.rst
+++ b/docs/quadratic_programming.rst
@@ -195,6 +195,9 @@ Example::
 
 It is also possible to specify only equality constraints or only inequality
 constraints by setting ``params_eq`` or ``params_ineq`` to ``None``.
+Use ``None`` for a missing constraint family rather than empty arrays, such as
+zero-row equality matrices. If both equality and inequality constraints are
+absent, use the unconstrained QP approach below instead of :class:`jaxopt.OSQP`.
 
 OSQP
 ~~~~
@@ -230,6 +233,12 @@ Example::
   print(sol.dual_ineq)
 
 See :class:`jaxopt.BoxOSQP` for a full description of the parameters.
+
+When using :class:`jaxopt.OSQP`, pass ``params_eq=None`` if there are no
+equality constraints, or ``params_ineq=None`` if there are no inequality
+constraints. At least one of these two arguments must be provided. Problems
+without constraints should be solved as unconstrained QPs, for example with
+conjugate gradient.
 
 .. topic:: Example
 

--- a/jaxopt/_src/osqp.py
+++ b/jaxopt/_src/osqp.py
@@ -1058,8 +1058,12 @@ class OSQP(base.Solver):
         a tuple (Q, c) with Q a pytree of matrices,
         or a tuple (params_Q, c) if ``matvec_Q`` is provided,
         or an arbitrary pytree if ``fun`` is provided.
-      params_eq: (A, b) or None if no equality constraints.
-      params_ineq: (G, h) or None if no inequality constraints.
+      params_eq: (A, b) or None if no equality constraints. Use None rather
+        than an empty equality matrix.
+      params_ineq: (G, h) or None if no inequality constraints. Use None
+        rather than an empty inequality matrix. At least one of params_eq or
+        params_ineq must be not None; use an unconstrained QP solver when both
+        constraint families are absent.
     Returns:
       (params, state), ``params = (primal_var, dual_var_eq, dual_var_ineq)``
     """


### PR DESCRIPTION
Addresses #570.

## What
- Clarify that missing OSQP equality or inequality constraint families should be passed as `None`, not as empty constraint arrays.
- Document that at least one constraint family must be provided for `OSQP`; fully unconstrained QPs should use the unconstrained QP path instead.
- Mirror that guidance in the `OSQP.run` docstring so the generated API docs include it.

## Testing
- `git diff --check`
- `python3.12 -m compileall -q jaxopt/_src/osqp.py`
- Temporary venv smoke test importing `OSQP` and checking the updated `run` docstring
- Temporary venv smoke test solving a small QP with `params_eq=None` and `params_ineq=(G, h)`

The full Sphinx docs build was not run locally because the docs requirements install the full documentation stack, including TensorFlow/Flax.