### PR TITLE
docs: clarify Bisection bound differentiation

### DIFF
--- a/docs/root_finding.rst
+++ b/docs/root_finding.rst
@@ -61,6 +61,14 @@ with respect to ``factor``::
 Under the hood, we use the implicit function theorem in order to differentiate the root.
 See the :ref:`implicit differentiation <implicit_diff>` section for more details.
 
+The bracketing values ``lower`` and ``upper`` are solver hyperparameters, not
+arguments of ``optimality_fun``.  Implicit differentiation therefore computes
+derivatives with respect to the arguments passed to ``run``, such as
+``factor`` above, but not with respect to ``lower`` or ``upper`` themselves.
+If the bracketing interval is computed from differentiable JAX values and is
+intended only to define the algorithm's search interval, stop its gradients
+before constructing ``Bisection``, for example with ``jax.lax.stop_gradient``.
+
 Scipy wrapper
 -------------
 

--- a/jaxopt/_src/bisection.py
+++ b/jaxopt/_src/bisection.py
@@ -48,8 +48,12 @@ class Bisection(base.IterativeSolver):
     optimality_fun: a function ``optimality_fun(x, *args, **kwargs)``
       where ``x`` is a 1d variable. The function should have opposite signs
       when evaluated at ``lower`` and at ``upper``.
-    lower: the lower end of the bracketing interval.
-    upper: the upper end of the bracketing interval.
+    lower: the lower end of the bracketing interval. This is a solver
+      hyperparameter, not an argument of ``optimality_fun``; implicit
+      differentiation is not with respect to this value.
+    upper: the upper end of the bracketing interval. This is a solver
+      hyperparameter, not an argument of ``optimality_fun``; implicit
+      differentiation is not with respect to this value.
     maxiter: maximum number of iterations.
     tol: tolerance.
     check_bracket: whether to check correctness of the bracketing interval.


### PR DESCRIPTION
Addresses #472.

## What
- Clarify in the root-finding docs that `Bisection` differentiates roots with respect to arguments passed to `run`, not with respect to the bracketing bounds.
- Note that `lower` and `upper` are solver hyperparameters and should have their gradients stopped when they are computed from differentiable JAX values only to define the search interval.
- Mirror that guidance in the `Bisection` docstring so generated API docs include it.

## Testing
- `git diff --check`
- `python3.12 -m compileall -q jaxopt/_src/bisection.py`
- Temporary venv smoke test importing `Bisection` and checking the updated docstring
- Temporary venv smoke test running the root-finding differentiation example with `jax.grad`

The full Sphinx docs build was not run locally because the docs requirements install the full documentation stack, including TensorFlow/Flax.